### PR TITLE
Fully support for CHW mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # Neural Network on Microcontroller (NNoM)
 [![Build Status](https://travis-ci.org/majianjia/nnom.svg?branch=master)](https://travis-ci.org/majianjia/nnom)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 NNoM is a high-level linference Neural Network library specifically for microcontrollers. 
 
@@ -16,6 +17,8 @@ NNoM is a high-level linference Neural Network library specifically for microcon
 
 The structure of NNoM is shown below:
 ![](docs/figures/nnom_structure.png)
+
+More detail avaialble in [Development Guide](docs/guide_development.md)
 
 Discussions welcome using [issues](https://github.com/majianjia/nnom/issues). Pull request welcome. QQ/TIM group: 763089399.
 
@@ -51,8 +54,6 @@ There is no need to learn TensorFlow/Lite or other libs.
 
 [5 min to NNoM Guide](docs/guide_5_min_to_nnom.md)
 
-[Development Guide](docs/guide_development.md)
-
 [The temporary guide](docs/A_Temporary_Guide_to_NNoM.md)
 
 [Porting and optimising Guide](docs/Porting_and_Optimisation_Guide.md) 
@@ -68,6 +69,8 @@ There is no need to learn TensorFlow/Lite or other libs.
 Please check [examples](https://github.com/majianjia/nnom/tree/master/examples) and choose one to start with. 
 
 ## Available Operations
+
+[[API Manual]](https://majianjia.github.io/nnom/)
 
 > *Notes: NNoM now supports both HWC and CHW formats. Some operation might not support both format currently. Please check the tables for the current status. *
 
@@ -109,7 +112,7 @@ Activation can be used by itself as layer, or can be attached to the previous la
 **Pooling Layers**
 
 | Pooling | HWC|CHW |Layer API|Comments|
-| ------ |-- |--|--|--|
+| ------ |---- |----|----|----|
 | Max Pooling  |✓|✓|MaxPool()||
 | Average Pooling | ✓|✓|AvgPool()||
 | Sum Pooling | ✓|✓|SumPool()| |
@@ -121,7 +124,7 @@ Activation can be used by itself as layer, or can be attached to the previous la
 
 | Matrix |HWC|CHW|Layer API|Comments|
 | ------ |-- |--|--|--|
-| Concatenate |✓|| Concat()| Concatenate through any axis|
+| Concatenate |✓|✓| Concat()| Concatenate through any axis|
 | Multiple  |✓|✓|Mult()||
 | Addition  |✓|✓|Add()||
 | Substraction  |✓|✓|Sub()||
@@ -135,7 +138,7 @@ NNoM now use the local pure C backend implementation by default. Thus, there is 
 ## Optimization
 You can select [CMSIS-NN/DSP](https://github.com/ARM-software/CMSIS_5/tree/develop/CMSIS/NN) as the backend for about 5x performance with ARM-Cortex-M4/7/33/35P. 
 
-Check [Porting and optimising Guide](docs/Porting_and_Optimisation_Guide.md) for detail. 
+Please check [Porting and optimising Guide](docs/Porting_and_Optimisation_Guide.md) for detail. 
 
 ## Contacts
 Jianjia Ma

--- a/README.md
+++ b/README.md
@@ -67,30 +67,31 @@ There is no need to learn TensorFlow/Lite or other libs.
 
 Please check [examples](https://github.com/majianjia/nnom/tree/master/examples) and choose one to start with. 
 
-
 ## Available Operations
+
+> *Notes: NNoM now supports both HWC and CHW formats. Some operation might not support both format currently. Please check the tables for the current status. *
 
 **Core Layers**
 
-| Layers | Status |Layer API|Comments|
-| ------ |-- |--|--|
-| Convolution  | Beta|Conv2D()|Support 1/2D|
-| Depthwise Conv | Beta|DW_Conv2D()|Support 1/2D|
-| Fully-connected | Beta| Dense()| |
-| Lambda |Alpha| Lambda() |single input / single output anonymous operation| 
-| Batch Normalization |Beta | N/A| This layer is merged to the last Conv by the script|
-| Flatten|Beta | Flatten()| |
-| SoftMax|Beta | SoftMax()| Softmax only has layer API| 
-| Activation|Beta| Activation()|A layer instance for activation|
-| Input/Output |Beta | Input()/Output()| |
-| Up Sampling | Beta|UpSample()||
-| Zero Padding | Beta |ZeroPadding()||
-| Cropping | Beta |Cropping()||
+| Layers |HWC|CHW |Layer API|Comments|
+| ------ |----|---- |------|------|
+| Convolution  |✓|✓|Conv2D()|Support 1/2D|
+| Depthwise Conv |✓|✓|DW_Conv2D()|Support 1/2D|
+| Fully-connected |✓|✓| Dense()| |
+| Lambda |✓|✓| Lambda() |single input / single output anonymous operation| 
+| Batch Normalization |✓| ✓| N/A| This layer is merged to the last Conv by the script|
+| Flatten|✓|✓| Flatten()| |
+| SoftMax|✓|✓| SoftMax()| Softmax only has layer API| 
+| Activation|✓|✓| Activation()|A layer instance for activation|
+| Input/Output |✓|✓| Input()/Output()| |
+| Up Sampling |✓| ✓|UpSample()||
+| Zero Padding | ✓| ✓|ZeroPadding()||
+| Cropping |✓ |✓ |Cropping()||
 
 **RNN Layers**
 
 | Layers | Status |Layer API|Comments|
-| ------ |-- |--|--|
+| ------ | ------ | ------| ------|
 | Recurrent NN | Under Dev.| RNN()| Under Developpment |
 | Simple RNN | Under Dev. | SimpleCell()| Under Developpment |
 | Gated Recurrent Network (GRU)| Under Dev. | GRUCell()| Under Developpment |
@@ -99,31 +100,32 @@ Please check [examples](https://github.com/majianjia/nnom/tree/master/examples) 
 
 Activation can be used by itself as layer, or can be attached to the previous layer as ["actail"](docs/A_Temporary_Guide_to_NNoM.md#addictionlly-activation-apis) to reduce memory cost.
 
-| Actrivation | Status |Layer API|Activation API|Comments|
+| Actrivation | HWC| CHW|Layer API|Activation API|Comments|
 | ------ |-- |--|--|--|
-| ReLU  | Beta|ReLU()|act_relu()||
-| TanH | Beta|TanH()|act_tanh()||
-|Sigmoid|Beta| Sigmoid()|act_sigmoid()||
+| ReLU  | ✓|✓|ReLU()|act_relu()||
+| TanH | ✓|✓|TanH()|act_tanh()||
+|Sigmoid|✓|✓| Sigmoid()|act_sigmoid()||
 
 **Pooling Layers**
 
-| Pooling | Status |Layer API|Comments|
-| ------ |-- |--|--|
-| Max Pooling  | Beta|MaxPool()||
-| Average Pooling | Beta|AvgPool()||
-| Sum Pooling | Beta|SumPool()| |
-| Global Max Pooling  | Beta|GlobalMaxPool()||
-| Global Average Pooling | Beta|GlobalAvgPool()||
-| Global Sum Pooling | Beta|GlobalSumPool()|A better alternative to Global average pooling in MCU before Softmax|
+| Pooling | HWC|CHW |Layer API|Comments|
+| ------ |-- |--|--|--|
+| Max Pooling  |✓|✓|MaxPool()||
+| Average Pooling | ✓|✓|AvgPool()||
+| Sum Pooling | ✓|✓|SumPool()| |
+| Global Max Pooling |✓|✓|GlobalMaxPool()||
+| Global Average Pooling |✓|✓|GlobalAvgPool()||
+| Global Sum Pooling |✓|✓|GlobalSumPool()|A better alternative to Global average pooling in MCU before Softmax|
 
 **Matrix Operations Layers**
 
-| Matrix | Status |Layer API|Comments|
-| ------ |-- |--|--|
-| Concatenate | | Concat()| Concatenate through any axis|
-| Multiple  |Beta |Mult()||
-| Addition  | Beta|Add()||
-| Substraction  | Beta|Sub()||
+| Matrix |HWC|CHW|Layer API|Comments|
+| ------ |-- |--|--|--|
+| Concatenate |✓|| Concat()| Concatenate through any axis|
+| Multiple  |✓|✓|Mult()||
+| Addition  |✓|✓|Add()||
+| Substraction  |✓|✓|Sub()||
+
 
 ## Dependencies
 

--- a/docs/api_layers.md
+++ b/docs/api_layers.md
@@ -18,6 +18,7 @@ nnom_layer_t* Input(nnom_shape_t input_shape, * p_buf);
 ~~~
 
 **A model must start with a Input layer** to copy input data from user memory space to NNoM memory space. 
+If NNoM is set to CHW format, the Input layer will also change the input format from HWC (regular store format for image in memory) to CHW during copying. 
 
 **Arguments**
 

--- a/docs/api_nnom_utils.md
+++ b/docs/api_nnom_utils.md
@@ -15,7 +15,7 @@ Tutorial is comming, before it arrives, please refer to [examples](https://githu
 ## generate_model()
 
 ~~~python
-generate_model(model, x_test, name='weights.h')
+generate_model(model, x_test, name='weights.h', format='hwc')
 ~~~
 
 **This is all you need**
@@ -31,11 +31,15 @@ This method is the most frequently used function for deployment.
 - **model:** the trained Keras model
 - **x_test:** the dataset used to check the output range of each layer.  
 - **name:** the name of the automatically generated c file. 
+- **format:** indicate the backend format, options between `'hwc'` and `'chw'`. See notes
 
 **Notes**
 
 - This method might not be updated from time to time with new features in NNoM. 
 - Currently, only support single input, single output models. 
+- The default backend format is set to 'hwc', also call 'channel last', which is the same format as CMSIS-NN. This format is optimal for CPU. 
+'chw' format, call 'channel first', is for MCU with hardware AI accelerator (such as [Kendryte K210](https://kendryte.com/)).
+This setting only affects the format in the backend. the frontend will always use 'HWC' for data shape. 
 
 ---
 
@@ -65,7 +69,7 @@ This function is to check the output range and generate the output shifting list
 ## generate_weights()
 
 ~~~python
-generate_weights(model, name='weights.h', shift_list=None)
+generate_weights(model, name='weights.h', format='hwc', shift_list=None)
 ~~~
 
 Scans all the layer which includes weights, quantise the weights and put them into the c header.
@@ -75,6 +79,7 @@ Scans all the layer which includes weights, quantise the weights and put them in
 - **model:** the trained Keras model
 - **name:** the c file name to store weigths.
 - **shift_list:** the shift list returned by `layers_output_ranges(model, x_test)`
+- **format:** indicate the backend format, options between `'hwc'` and `'chw'`. See notes in [generate_model()](#generate_model)
 
 **Notes**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # Neural Network on Microcontroller (NNoM)
 
 [![Build Status](https://travis-ci.org/majianjia/nnom.svg?branch=master)](https://travis-ci.org/majianjia/nnom)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 NNoM is a high-level inference Neural Network library specifically for microcontrollers. 
 
@@ -16,6 +17,8 @@ NNoM is a high-level inference Neural Network library specifically for microcont
 
 The structure of NNoM is shown below:
 ![](figures/nnom_structure.png)
+
+More detail avaialble in [Development Guide](guide_development.md)
 
 ## Licenses
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,27 +97,29 @@ Check [Porting and optimising Guide](Porting_and_Optimisation_Guide.md) for deta
 ---
 ## Available Operations
 
+> *Notes: NNoM now supports both HWC and CHW formats. Some operation might not support both format currently. Please check the tables for the current status. *
+
 **Core Layers**
 
-| Layers | Status |Layer API|Comments|
-| ------ |-- |--|--|
-| Convolution  | Beta|Conv2D()|Support 1/2D|
-| Depthwise Conv | Beta|DW_Conv2D()|Support 1/2D|
-| Fully-connected | Beta| Dense()| |
-| Lambda |Alpha| Lambda() |single input / single output anonymous operation| 
-| Batch Normalization |Beta | N/A| This layer is merged to the last Conv by the script|
-| Flatten|Beta | Flatten()| |
-| SoftMax|Beta | SoftMax()| Softmax only has layer API| 
-| Activation|Beta| Activation()|A layer instance for activation|
-| Input/Output |Beta | Input()/Output()| |
-| Up Sampling | Beta|UpSample()||
-| Zero Padding | Beta |ZeroPadding()||
-| Cropping | Beta |Cropping()||
+| Layers |HWC|CHW |Layer API|Comments|
+| ------ |----|---- |------|------|
+| Convolution  |✓|✓|Conv2D()|Support 1/2D|
+| Depthwise Conv |✓|✓|DW_Conv2D()|Support 1/2D|
+| Fully-connected |✓|✓| Dense()| |
+| Lambda |✓|✓| Lambda() |single input / single output anonymous operation| 
+| Batch Normalization |✓| ✓| N/A| This layer is merged to the last Conv by the script|
+| Flatten|✓|✓| Flatten()| |
+| SoftMax|✓|✓| SoftMax()| Softmax only has layer API| 
+| Activation|✓|✓| Activation()|A layer instance for activation|
+| Input/Output |✓|✓| Input()/Output()| |
+| Up Sampling |✓| ✓|UpSample()||
+| Zero Padding | ✓| ✓|ZeroPadding()||
+| Cropping |✓ |✓ |Cropping()||
 
 **RNN Layers**
 
 | Layers | Status |Layer API|Comments|
-| ------ |-- |--|--|
+| ------ | ------ | ------| ------|
 | Recurrent NN | Under Dev.| RNN()| Under Developpment |
 | Simple RNN | Under Dev. | SimpleCell()| Under Developpment |
 | Gated Recurrent Network (GRU)| Under Dev. | GRUCell()| Under Developpment |
@@ -126,28 +128,28 @@ Check [Porting and optimising Guide](Porting_and_Optimisation_Guide.md) for deta
 
 Activation can be used by itself as layer, or can be attached to the previous layer as ["actail"](docs/A_Temporary_Guide_to_NNoM.md#addictionlly-activation-apis) to reduce memory cost.
 
-| Actrivation | Status |Layer API|Activation API|Comments|
+| Actrivation | HWC| CHW|Layer API|Activation API|Comments|
 | ------ |-- |--|--|--|
-| ReLU  | Beta|ReLU()|act_relu()||
-| TanH | Beta|TanH()|act_tanh()||
-|Sigmoid|Beta| Sigmoid()|act_sigmoid()||
+| ReLU  | ✓|✓|ReLU()|act_relu()||
+| TanH | ✓|✓|TanH()|act_tanh()||
+|Sigmoid|✓|✓| Sigmoid()|act_sigmoid()||
 
 **Pooling Layers**
 
-| Pooling | Status |Layer API|Comments|
-| ------ |-- |--|--|
-| Max Pooling  | Beta|MaxPool()||
-| Average Pooling | Beta|AvgPool()||
-| Sum Pooling | Beta|SumPool()| |
-| Global Max Pooling  | Beta|GlobalMaxPool()||
-| Global Average Pooling | Beta|GlobalAvgPool()||
-| Global Sum Pooling | Beta|GlobalSumPool()|A better alternative to Global average pooling in MCU before Softmax|
+| Pooling | HWC|CHW |Layer API|Comments|
+| ------ |-- |--|--|--|
+| Max Pooling  |✓|✓|MaxPool()||
+| Average Pooling | ✓|✓|AvgPool()||
+| Sum Pooling | ✓|✓|SumPool()| |
+| Global Max Pooling |✓|✓|GlobalMaxPool()||
+| Global Average Pooling |✓|✓|GlobalAvgPool()||
+| Global Sum Pooling |✓|✓|GlobalSumPool()|A better alternative to Global average pooling in MCU before Softmax|
 
 **Matrix Operations Layers**
 
-| Matrix | Status |Layer API|Comments|
-| ------ |-- |--|--|
-| Concatenate | | Concat()| Concatenate through any axis|
-| Multiple  |Beta |Mult()||
-| Addition  | Beta|Add()||
-| Substraction  | Beta|Sub()||
+| Matrix |HWC|CHW|Layer API|Comments|
+| ------ |-- |--|--|--|
+| Concatenate |✓|| Concat()| Concatenate through any axis|
+| Multiple  |✓|✓|Mult()||
+| Addition  |✓|✓|Add()||
+| Substraction  |✓|✓|Sub()||

--- a/inc/nnom_local.h
+++ b/inc/nnom_local.h
@@ -190,6 +190,25 @@ void local_convolve_HWC_q7_nonsquare(const q7_t * Im_in,            // input ima
                                        const uint16_t dim_im_out_y, // output image dimension y
                                        q15_t * bufferA,             //buffer space for input
                                        q7_t * bufferB);             //buffer space for output
+									   
+void local_convolve_CHW_q7_nonsquare(const q7_t * Im_in,            // input image
+                                       const uint16_t dim_im_in_x,  // input image dimention x
+                                       const uint16_t dim_im_in_y,  // input image dimention y
+                                       const uint16_t ch_im_in,     // number of input image channels
+                                       const q7_t * wt,             // kernel weights 
+                                       const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+                                       const uint16_t dim_kernel_x, // filter kernel size x
+                                       const uint16_t dim_kernel_y, // filter kernel size y
+                                       const uint16_t padding_x,    // padding sizes x
+                                       const uint16_t padding_y,    // padding sizes y
+                                       const uint16_t stride_x,     // stride x
+                                       const uint16_t stride_y,     // stride y
+                                       const q7_t * bias,           // bias
+                                       const uint16_t bias_shift, const uint16_t out_shift, q7_t * Im_out,  // output image
+                                       const uint16_t dim_im_out_x, // output image dimension x
+                                       const uint16_t dim_im_out_y, // output image dimension y
+                                       q15_t * bufferA,             //buffer space for input
+                                       q7_t * bufferB);             //buffer space for output
 
 void local_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t * Im_in,  // input image
                                                        const uint16_t dim_im_in_x,  // input image dimention x

--- a/inc/nnom_local.h
+++ b/inc/nnom_local.h
@@ -59,244 +59,265 @@ static inline int __NNOM_USAT(int32_t value, int32_t bit) {
 // https://github.com/ARM-software/CMSIS_5
 //
 void local_avepool_q7_HWC(const q7_t * Im_in, // input image
-                            const uint16_t dim_im_in_x,   	// input image dimension x or W
-							const uint16_t dim_im_in_y,   	// input image dimension y or H
-                            const uint16_t ch_im_in,    	// number of input image channels
-                            const uint16_t dim_kernel_x,  	// window kernel size
-							const uint16_t dim_kernel_y,  	// window kernel size
-                            const uint16_t padding_x, 		// padding sizes
-							const uint16_t padding_y, 		// padding sizes
-                            const uint16_t stride_x,  		// stride
-							const uint16_t stride_y,  		// stride
-                            const uint16_t dim_im_out_x,  	// output image dimension x or W
-							const uint16_t dim_im_out_y,  	// output image dimension y or H
-                            q7_t * bufferA, 				// a buffer for local storage, NULL by now
-                            q7_t * Im_out);
+	const uint16_t dim_im_in_x,   	// input image dimension x or W
+	const uint16_t dim_im_in_y,   	// input image dimension y or H
+	const uint16_t ch_im_in,    	// number of input image channels
+	const uint16_t dim_kernel_x,  	// window kernel size
+	const uint16_t dim_kernel_y,  	// window kernel size
+	const uint16_t padding_x, 		// padding sizes
+	const uint16_t padding_y, 		// padding sizes
+	const uint16_t stride_x,  		// stride
+	const uint16_t stride_y,  		// stride
+	const uint16_t dim_im_out_x,  	// output image dimension x or W
+	const uint16_t dim_im_out_y,  	// output image dimension y or H
+	q7_t * bufferA, 				// a buffer for local storage, NULL by now
+	q7_t * Im_out);
 
 void local_avepool_q7_CHW(const q7_t * Im_in, // input image
-                            const uint16_t dim_im_in_x,   	// input image dimension x or W
-							const uint16_t dim_im_in_y,   	// input image dimension y or H
-                            const uint16_t ch_im_in,    	// number of input image channels
-                            const uint16_t dim_kernel_x,  	// window kernel size
-							const uint16_t dim_kernel_y,  	// window kernel size
-                            const uint16_t padding_x, 		// padding sizes
-							const uint16_t padding_y, 		// padding sizes
-                            const uint16_t stride_x,  		// stride
-							const uint16_t stride_y,  		// stride
-                            const uint16_t dim_im_out_x,  	// output image dimension x or W
-							const uint16_t dim_im_out_y,  	// output image dimension y or H
-                            q7_t * bufferA, 				// a buffer for local storage, NULL by now
-                            q7_t * Im_out);
+	const uint16_t dim_im_in_x,   	// input image dimension x or W
+	const uint16_t dim_im_in_y,   	// input image dimension y or H
+	const uint16_t ch_im_in,    	// number of input image channels
+	const uint16_t dim_kernel_x,  	// window kernel size
+	const uint16_t dim_kernel_y,  	// window kernel size
+	const uint16_t padding_x, 		// padding sizes
+	const uint16_t padding_y, 		// padding sizes
+	const uint16_t stride_x,  		// stride
+	const uint16_t stride_y,  		// stride
+	const uint16_t dim_im_out_x,  	// output image dimension x or W
+	const uint16_t dim_im_out_y,  	// output image dimension y or H
+	q7_t * bufferA, 				// a buffer for local storage, NULL by now
+	q7_t * Im_out);
 
 // modified from CMSIS-NN test_ref                            
 void local_maxpool_q7_HWC(const q7_t * Im_in, 				// input image
-                            const uint16_t dim_im_in_x,   	// input image dimension x or W
-							const uint16_t dim_im_in_y,   	// input image dimension y or H
-                            const uint16_t ch_im_in,    	// number of input image channels
-                            const uint16_t dim_kernel_x,  	// window kernel size
-							const uint16_t dim_kernel_y,  	// window kernel size
-                            const uint16_t padding_x, 		// padding sizes
-							const uint16_t padding_y, 		// padding sizes
-                            const uint16_t stride_x,  		// stride
-							const uint16_t stride_y,  		// stride
-                            const uint16_t dim_im_out_x,  	// output image dimension x or W
-							const uint16_t dim_im_out_y,  	// output image dimension y or H
-                            q7_t * bufferA, 				// a buffer for local storage, NULL by now
-                            q7_t * Im_out);
+	const uint16_t dim_im_in_x,   	// input image dimension x or W
+	const uint16_t dim_im_in_y,   	// input image dimension y or H
+	const uint16_t ch_im_in,    	// number of input image channels
+	const uint16_t dim_kernel_x,  	// window kernel size
+	const uint16_t dim_kernel_y,  	// window kernel size
+	const uint16_t padding_x, 		// padding sizes
+	const uint16_t padding_y, 		// padding sizes
+	const uint16_t stride_x,  		// stride
+	const uint16_t stride_y,  		// stride
+	const uint16_t dim_im_out_x,  	// output image dimension x or W
+	const uint16_t dim_im_out_y,  	// output image dimension y or H
+	q7_t * bufferA, 				// a buffer for local storage, NULL by now
+	q7_t * Im_out);
 
 void local_maxpool_q7_CHW(const q7_t * Im_in, 				// input image
-                            const uint16_t dim_im_in_x,   	// input image dimension x or W
-							const uint16_t dim_im_in_y,   	// input image dimension y or H
-                            const uint16_t ch_im_in,    	// number of input image channels
-                            const uint16_t dim_kernel_x,  	// window kernel size
-							const uint16_t dim_kernel_y,  	// window kernel size
-                            const uint16_t padding_x, 		// padding sizes
-							const uint16_t padding_y, 		// padding sizes
-                            const uint16_t stride_x,  		// stride
-							const uint16_t stride_y,  		// stride
-                            const uint16_t dim_im_out_x,  	// output image dimension x or W
-							const uint16_t dim_im_out_y,  	// output image dimension y or H
-                            q7_t * bufferA, 				// a buffer for local storage, NULL by now
-                            q7_t * Im_out);
+	const uint16_t dim_im_in_x,   	// input image dimension x or W
+	const uint16_t dim_im_in_y,   	// input image dimension y or H
+	const uint16_t ch_im_in,    	// number of input image channels
+	const uint16_t dim_kernel_x,  	// window kernel size
+	const uint16_t dim_kernel_y,  	// window kernel size
+	const uint16_t padding_x, 		// padding sizes
+	const uint16_t padding_y, 		// padding sizes
+	const uint16_t stride_x,  		// stride
+	const uint16_t stride_y,  		// stride
+	const uint16_t dim_im_out_x,  	// output image dimension x or W
+	const uint16_t dim_im_out_y,  	// output image dimension y or H
+	q7_t * bufferA, 				// a buffer for local storage, NULL by now
+	q7_t * Im_out);
 							
 int32_t local_sumpool_q7_HWC(const q7_t * Im_in, // input image
-                            const uint16_t dim_im_in_x,   	// input image dimension x or W
-							const uint16_t dim_im_in_y,   	// input image dimension y or H
-                            const uint16_t ch_im_in,    	// number of input image channels
-                            const uint16_t dim_kernel_x,  	// window kernel size
-							const uint16_t dim_kernel_y,  	// window kernel size
-                            const uint16_t padding_x, 		// padding sizes
-							const uint16_t padding_y, 		// padding sizes
-                            const uint16_t stride_x,  		// stride
-							const uint16_t stride_y,  		// stride
-                            const uint16_t dim_im_out_x,  	// output image dimension x or W
-							const uint16_t dim_im_out_y,  	// output image dimension y or H
-                            q7_t * bufferA, 				// a buffer for local storage, size = 4*output_size
-                            q7_t * Im_out);
+	const uint16_t dim_im_in_x,   	// input image dimension x or W
+	const uint16_t dim_im_in_y,   	// input image dimension y or H
+	const uint16_t ch_im_in,    	// number of input image channels
+	const uint16_t dim_kernel_x,  	// window kernel size
+	const uint16_t dim_kernel_y,  	// window kernel size
+	const uint16_t padding_x, 		// padding sizes
+	const uint16_t padding_y, 		// padding sizes
+	const uint16_t stride_x,  		// stride
+	const uint16_t stride_y,  		// stride
+	const uint16_t dim_im_out_x,  	// output image dimension x or W
+	const uint16_t dim_im_out_y,  	// output image dimension y or H
+	q7_t * bufferA, 				// a buffer for local storage, size = 4*output_size
+	q7_t * Im_out);
 							
 int32_t local_sumpool_q7_CHW(const q7_t * Im_in, // input image
-                            const uint16_t dim_im_in_x,   	// input image dimension x or W
-							const uint16_t dim_im_in_y,   	// input image dimension y or H
-                            const uint16_t ch_im_in,    	// number of input image channels
-                            const uint16_t dim_kernel_x,  	// window kernel size
-							const uint16_t dim_kernel_y,  	// window kernel size
-                            const uint16_t padding_x, 		// padding sizes
-							const uint16_t padding_y, 		// padding sizes
-                            const uint16_t stride_x,  		// stride
-							const uint16_t stride_y,  		// stride
-                            const uint16_t dim_im_out_x,  	// output image dimension x or W
-							const uint16_t dim_im_out_y,  	// output image dimension y or H
-                            q7_t * bufferA, 				// a buffer for local storage, size = 4*output_size
-                            q7_t * Im_out);
+	const uint16_t dim_im_in_x,   	// input image dimension x or W
+	const uint16_t dim_im_in_y,   	// input image dimension y or H
+	const uint16_t ch_im_in,    	// number of input image channels
+	const uint16_t dim_kernel_x,  	// window kernel size
+	const uint16_t dim_kernel_y,  	// window kernel size
+	const uint16_t padding_x, 		// padding sizes
+	const uint16_t padding_y, 		// padding sizes
+	const uint16_t stride_x,  		// stride
+	const uint16_t stride_y,  		// stride
+	const uint16_t dim_im_out_x,  	// output image dimension x or W
+	const uint16_t dim_im_out_y,  	// output image dimension y or H
+	q7_t * bufferA, 				// a buffer for local storage, size = 4*output_size
+	q7_t * Im_out);
 
 // customised up sample pooling
 void local_up_sampling_q7_HWC(const q7_t *Im_in,       // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // NULL
-                          q7_t *Im_out);
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // NULL
+	q7_t *Im_out);
 						  
 void local_up_sampling_q7_CHW(const q7_t *Im_in,       // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // NULL
-                          q7_t *Im_out);
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // NULL
+	q7_t *Im_out);
 
 void local_convolve_HWC_q7_nonsquare(const q7_t * Im_in,            // input image
-                                       const uint16_t dim_im_in_x,  // input image dimention x
-                                       const uint16_t dim_im_in_y,  // input image dimention y
-                                       const uint16_t ch_im_in,     // number of input image channels
-                                       const q7_t * wt,             // kernel weights 
-                                       const uint16_t ch_im_out,    // number of filters, i.e., output image channels
-                                       const uint16_t dim_kernel_x, // filter kernel size x
-                                       const uint16_t dim_kernel_y, // filter kernel size y
-                                       const uint16_t padding_x,    // padding sizes x
-                                       const uint16_t padding_y,    // padding sizes y
-                                       const uint16_t stride_x,     // stride x
-                                       const uint16_t stride_y,     // stride y
-                                       const q7_t * bias,           // bias
-                                       const uint16_t bias_shift, const uint16_t out_shift, q7_t * Im_out,  // output image
-                                       const uint16_t dim_im_out_x, // output image dimension x
-                                       const uint16_t dim_im_out_y, // output image dimension y
-                                       q15_t * bufferA,             //buffer space for input
-                                       q7_t * bufferB);             //buffer space for output
+	const uint16_t dim_im_in_x,  // input image dimention x
+	const uint16_t dim_im_in_y,  // input image dimention y
+	const uint16_t ch_im_in,     // number of input image channels
+	const q7_t * wt,             // kernel weights 
+	const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x, // filter kernel size x
+	const uint16_t dim_kernel_y, // filter kernel size y
+	const uint16_t padding_x,    // padding sizes x
+	const uint16_t padding_y,    // padding sizes y
+	const uint16_t stride_x,     // stride x
+	const uint16_t stride_y,     // stride y
+	const q7_t * bias,           // bias
+	const uint16_t bias_shift, const uint16_t out_shift, q7_t * Im_out,  // output image
+	const uint16_t dim_im_out_x, // output image dimension x
+	const uint16_t dim_im_out_y, // output image dimension y
+	q15_t * bufferA,             //buffer space for input
+	q7_t * bufferB);             //buffer space for output
 									   
 void local_convolve_CHW_q7_nonsquare(const q7_t * Im_in,            // input image
-                                       const uint16_t dim_im_in_x,  // input image dimention x
-                                       const uint16_t dim_im_in_y,  // input image dimention y
-                                       const uint16_t ch_im_in,     // number of input image channels
-                                       const q7_t * wt,             // kernel weights 
-                                       const uint16_t ch_im_out,    // number of filters, i.e., output image channels
-                                       const uint16_t dim_kernel_x, // filter kernel size x
-                                       const uint16_t dim_kernel_y, // filter kernel size y
-                                       const uint16_t padding_x,    // padding sizes x
-                                       const uint16_t padding_y,    // padding sizes y
-                                       const uint16_t stride_x,     // stride x
-                                       const uint16_t stride_y,     // stride y
-                                       const q7_t * bias,           // bias
-                                       const uint16_t bias_shift, const uint16_t out_shift, q7_t * Im_out,  // output image
-                                       const uint16_t dim_im_out_x, // output image dimension x
-                                       const uint16_t dim_im_out_y, // output image dimension y
-                                       q15_t * bufferA,             //buffer space for input
-                                       q7_t * bufferB);             //buffer space for output
+	const uint16_t dim_im_in_x,  // input image dimention x
+	const uint16_t dim_im_in_y,  // input image dimention y
+	const uint16_t ch_im_in,     // number of input image channels
+	const q7_t * wt,             // kernel weights 
+	const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x, // filter kernel size x
+	const uint16_t dim_kernel_y, // filter kernel size y
+	const uint16_t padding_x,    // padding sizes x
+	const uint16_t padding_y,    // padding sizes y
+	const uint16_t stride_x,     // stride x
+	const uint16_t stride_y,     // stride y
+	const q7_t * bias,           // bias
+	const uint16_t bias_shift, const uint16_t out_shift, q7_t * Im_out,  // output image
+	const uint16_t dim_im_out_x, // output image dimension x
+	const uint16_t dim_im_out_y, // output image dimension y
+	q15_t * bufferA,             //buffer space for input
+	q7_t * bufferB);             //buffer space for output
 
 void local_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t * Im_in,  // input image
-                                                       const uint16_t dim_im_in_x,  // input image dimention x
-                                                       const uint16_t dim_im_in_y,  // input image dimention y
-                                                       const uint16_t ch_im_in, // number of input image channels
-                                                       const q7_t * wt, // kernel weights 
-                                                       const uint16_t ch_im_out,    // number of filters, i.e., output image channels
-                                                       const uint16_t dim_kernel_x, // filter kernel size x
-                                                       const uint16_t dim_kernel_y, // filter kernel size y
-                                                       const uint16_t padding_x,    // padding sizes x
-                                                       const uint16_t padding_y,    // padding sizes y
-                                                       const uint16_t stride_x, // stride x
-                                                       const uint16_t stride_y, // stride y
-                                                       const q7_t * bias,   // bias
-                                                       const uint16_t bias_shift,   // amount of left-shift for bias
-                                                       const uint16_t out_shift,    // amount of right-shift for output
-                                                       q7_t * Im_out,   // output image
-                                                       const uint16_t dim_im_out_x, // output image dimension x
-                                                       const uint16_t dim_im_out_y, // output image dimension y
-                                                       q15_t * bufferA, //buffer space for input
-                                                       q7_t * bufferB);   //buffer space for output
+	const uint16_t dim_im_in_x,  // input image dimention x
+	const uint16_t dim_im_in_y,  // input image dimention y
+	const uint16_t ch_im_in, // number of input image channels
+	const q7_t * wt, // kernel weights 
+	const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x, // filter kernel size x
+	const uint16_t dim_kernel_y, // filter kernel size y
+	const uint16_t padding_x,    // padding sizes x
+	const uint16_t padding_y,    // padding sizes y
+	const uint16_t stride_x, // stride x
+	const uint16_t stride_y, // stride y
+	const q7_t * bias,   // bias
+	const uint16_t bias_shift,   // amount of left-shift for bias
+	const uint16_t out_shift,    // amount of right-shift for output
+	q7_t * Im_out,   // output image
+	const uint16_t dim_im_out_x, // output image dimension x
+	const uint16_t dim_im_out_y, // output image dimension y
+	q15_t * bufferA, //buffer space for input
+	q7_t * bufferB);   //buffer space for output
+													   
+void local_depthwise_separable_conv_CHW_q7_nonsquare(const q7_t *Im_in,           // input image
+	const uint16_t dim_im_in_x,  // input image dimention x
+	const uint16_t dim_im_in_y,  // input image dimention y
+	const uint16_t ch_im_in,     // number of input image channels
+	const q7_t *wt,              // kernel weights
+	const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x, // filter kernel size x
+	const uint16_t dim_kernel_y, // filter kernel size y
+	const uint16_t padding_x,    // padding sizes x
+	const uint16_t padding_y,    // padding sizes y
+	const uint16_t stride_x,     // stride x
+	const uint16_t stride_y,     // stride y
+	const q7_t *bias,            // bias
+	const uint16_t bias_shift,   // amount of left-shift for bias
+	const uint16_t out_shift,    // amount of right-shift for output
+	q7_t *Im_out,                // output image
+	const uint16_t dim_im_out_x, // output image dimension x
+	const uint16_t dim_im_out_y, // output image dimension y
+	q15_t *bufferA,              //buffer space for input
+	q7_t *bufferB);                //buffer space for output
 
 void local_zero_padding_HWC_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y);  // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y);  // output image dimension y 
 						 
 void local_zero_padding_CHW_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y);  // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y);  // output image dimension y 
 						 
 void local_cropping_HWC_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y);  // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y);  // output image dimension y 
 						 
 void local_cropping_CHW_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y);  // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y);  // output image dimension y 
 
 void local_fully_connected_q7_opt(const q7_t * pV,    // pointer to vector
-                                    const q7_t * pM,    // pointer to matrix
-                                    const uint16_t dim_vec, // length of the vector
-                                    const uint16_t num_of_rows, // numCol of A
-                                    const uint16_t bias_shift,  // amount of left-shift for bias
-                                    const uint16_t out_shift,   // amount of right-shift for output
-                                    const q7_t * bias, q7_t * pOut, // output operand
-                                    q15_t * vec_buffer);
+	const q7_t * pM,    // pointer to matrix
+	const uint16_t dim_vec, // length of the vector
+	const uint16_t num_of_rows, // numCol of A
+	const uint16_t bias_shift,  // amount of left-shift for bias
+	const uint16_t out_shift,   // amount of right-shift for output
+	const q7_t * bias, q7_t * pOut, // output operand
+	q15_t * vec_buffer);
 
 
 void local_fully_connected_q7(const q7_t * pV,    // pointer to vector
-                                const q7_t * pM,    // pointer to matrix
-                                const uint16_t dim_vec, // length of the vector
-                                const uint16_t num_of_rows, // numCol of A
-                                const uint16_t bias_shift,  // amount of left-shift for bias
-                                const uint16_t out_shift,   // amount of right-shift for output
-                                const q7_t * bias, q7_t * pOut, // output operand
-                                q15_t * vec_buffer);
+	const q7_t * pM,    // pointer to matrix
+	const uint16_t dim_vec, // length of the vector
+	const uint16_t num_of_rows, // numCol of A
+	const uint16_t bias_shift,  // amount of left-shift for bias
+	const uint16_t out_shift,   // amount of right-shift for output
+	const q7_t * bias, q7_t * pOut, // output operand
+	q15_t * vec_buffer);
 
 
 // softmax

--- a/inc/nnom_local.h
+++ b/inc/nnom_local.h
@@ -55,10 +55,25 @@ static inline int __NNOM_USAT(int32_t value, int32_t bit) {
 #endif
 
 
-// Those functions/tables below are modifed from CMSIS-NN lib
+// Those functions/tables below are partially modifed from CMSIS-NN lib
 // https://github.com/ARM-software/CMSIS_5
 //
 void local_avepool_q7_HWC(const q7_t * Im_in, // input image
+                            const uint16_t dim_im_in_x,   	// input image dimension x or W
+							const uint16_t dim_im_in_y,   	// input image dimension y or H
+                            const uint16_t ch_im_in,    	// number of input image channels
+                            const uint16_t dim_kernel_x,  	// window kernel size
+							const uint16_t dim_kernel_y,  	// window kernel size
+                            const uint16_t padding_x, 		// padding sizes
+							const uint16_t padding_y, 		// padding sizes
+                            const uint16_t stride_x,  		// stride
+							const uint16_t stride_y,  		// stride
+                            const uint16_t dim_im_out_x,  	// output image dimension x or W
+							const uint16_t dim_im_out_y,  	// output image dimension y or H
+                            q7_t * bufferA, 				// a buffer for local storage, NULL by now
+                            q7_t * Im_out);
+
+void local_avepool_q7_CHW(const q7_t * Im_in, // input image
                             const uint16_t dim_im_in_x,   	// input image dimension x or W
 							const uint16_t dim_im_in_y,   	// input image dimension y or H
                             const uint16_t ch_im_in,    	// number of input image channels
@@ -89,7 +104,37 @@ void local_maxpool_q7_HWC(const q7_t * Im_in, 				// input image
                             q7_t * bufferA, 				// a buffer for local storage, NULL by now
                             q7_t * Im_out);
 
+void local_maxpool_q7_CHW(const q7_t * Im_in, 				// input image
+                            const uint16_t dim_im_in_x,   	// input image dimension x or W
+							const uint16_t dim_im_in_y,   	// input image dimension y or H
+                            const uint16_t ch_im_in,    	// number of input image channels
+                            const uint16_t dim_kernel_x,  	// window kernel size
+							const uint16_t dim_kernel_y,  	// window kernel size
+                            const uint16_t padding_x, 		// padding sizes
+							const uint16_t padding_y, 		// padding sizes
+                            const uint16_t stride_x,  		// stride
+							const uint16_t stride_y,  		// stride
+                            const uint16_t dim_im_out_x,  	// output image dimension x or W
+							const uint16_t dim_im_out_y,  	// output image dimension y or H
+                            q7_t * bufferA, 				// a buffer for local storage, NULL by now
+                            q7_t * Im_out);
+							
 int32_t local_sumpool_q7_HWC(const q7_t * Im_in, // input image
+                            const uint16_t dim_im_in_x,   	// input image dimension x or W
+							const uint16_t dim_im_in_y,   	// input image dimension y or H
+                            const uint16_t ch_im_in,    	// number of input image channels
+                            const uint16_t dim_kernel_x,  	// window kernel size
+							const uint16_t dim_kernel_y,  	// window kernel size
+                            const uint16_t padding_x, 		// padding sizes
+							const uint16_t padding_y, 		// padding sizes
+                            const uint16_t stride_x,  		// stride
+							const uint16_t stride_y,  		// stride
+                            const uint16_t dim_im_out_x,  	// output image dimension x or W
+							const uint16_t dim_im_out_y,  	// output image dimension y or H
+                            q7_t * bufferA, 				// a buffer for local storage, size = 4*output_size
+                            q7_t * Im_out);
+							
+int32_t local_sumpool_q7_CHW(const q7_t * Im_in, // input image
                             const uint16_t dim_im_in_x,   	// input image dimension x or W
 							const uint16_t dim_im_in_y,   	// input image dimension y or H
                             const uint16_t ch_im_in,    	// number of input image channels
@@ -106,6 +151,17 @@ int32_t local_sumpool_q7_HWC(const q7_t * Im_in, // input image
 
 // customised up sample pooling
 void local_up_sampling_q7_HWC(const q7_t *Im_in,       // input image
+                          const uint16_t dim_im_in_x,  // input image dimension x or W
+                          const uint16_t dim_im_in_y,  // input image dimension y or H
+                          const uint16_t ch_im_in,     // number of input image channels
+                          const uint16_t dim_kernel_x, // window kernel size
+                          const uint16_t dim_kernel_y, // window kernel size
+                          const uint16_t dim_im_out_x, // output image dimension x or W
+                          const uint16_t dim_im_out_y, // output image dimension y or H
+                          q7_t *bufferA,               // NULL
+                          q7_t *Im_out);
+						  
+void local_up_sampling_q7_CHW(const q7_t *Im_in,       // input image
                           const uint16_t dim_im_in_x,  // input image dimension x or W
                           const uint16_t dim_im_in_y,  // input image dimension y or H
                           const uint16_t ch_im_in,     // number of input image channels
@@ -168,7 +224,31 @@ void local_zero_padding_HWC_q7(const q7_t *Im_in,           // input image
 						 const uint16_t dim_im_out_x,   // output image dimension x
 						 const uint16_t dim_im_out_y);  // output image dimension y 
 						 
+void local_zero_padding_CHW_q7(const q7_t *Im_in,           // input image
+						 const uint16_t dim_im_in_x,    // input image dimention x
+						 const uint16_t dim_im_in_y,    // input image dimention y
+						 const uint16_t ch_im_in,       // number of input image channels
+						 const uint16_t padding_top,    // padding sizes y
+						 const uint16_t padding_bottom, // padding sizes y
+						 const uint16_t padding_left,   // padding sizes x
+						 const uint16_t padding_right,  // padding sizes x
+						 q7_t *Im_out,                  // output image
+						 const uint16_t dim_im_out_x,   // output image dimension x
+						 const uint16_t dim_im_out_y);  // output image dimension y 
+						 
 void local_cropping_HWC_q7(const q7_t *Im_in,           // input image
+						 const uint16_t dim_im_in_x,    // input image dimention x
+						 const uint16_t dim_im_in_y,    // input image dimention y
+						 const uint16_t ch_im_in,       // number of input image channels
+						 const uint16_t padding_top,    // padding sizes y
+						 const uint16_t padding_bottom, // padding sizes y
+						 const uint16_t padding_left,   // padding sizes x
+						 const uint16_t padding_right,  // padding sizes x
+						 q7_t *Im_out,                  // output image
+						 const uint16_t dim_im_out_x,   // output image dimension x
+						 const uint16_t dim_im_out_y);  // output image dimension y 
+						 
+void local_cropping_CHW_q7(const q7_t *Im_in,           // input image
 						 const uint16_t dim_im_in_x,    // input image dimention x
 						 const uint16_t dim_im_in_y,    // input image dimention y
 						 const uint16_t ch_im_in,       // number of input image channels
@@ -295,9 +375,6 @@ static const q7_t nnom_tanh_table_q7[256] = {
     0x9f, 0xa2, 0xa6, 0xaa, 0xaf, 0xb4, 0xb9, 0xbf,
     0xc5, 0xcb, 0xd2, 0xd9, 0xe1, 0xe8, 0xf0, 0xf8,
 };
-
-
-
 
 
 #endif

--- a/inc/nnom_run.h
+++ b/inc/nnom_run.h
@@ -45,4 +45,7 @@ nnom_status_t add_run(nnom_layer_t *layer);
 nnom_status_t sub_run(nnom_layer_t *layer);
 nnom_status_t mult_run(nnom_layer_t *layer);
 
+void hwc2chw_q7(nnom_shape_t shape, q7_t* p_in, q7_t* p_out);
+void chw2hwc_q7(nnom_shape_t shape, q7_t* p_in, q7_t* p_out);
+
 #endif

--- a/port/nnom_port.h
+++ b/port/nnom_port.h
@@ -20,20 +20,27 @@
 #include <stdio.h>
 
 // memory interfaces
-#define nnom_malloc(n)   	malloc(n) 
-#define nnom_free(p)		free(p)
-#define nnom_memset(p,v,s)	memset(p,v,s)
+#define nnom_malloc(n)      malloc(n) 
+#define nnom_free(p)        free(p)
+#define nnom_memset(p,v,s)  memset(p,v,s)
 
 // runtime & debuges
-#define nnom_us_get()		0
-#define nnom_ms_get()		0
-#define NNOM_LOG(...)			printf(__VA_ARGS__)
+#define nnom_us_get()       0
+#define nnom_ms_get()       0
+#define NNOM_LOG(...)       printf(__VA_ARGS__)
 
 // NNoM configuration
 #define NNOM_BLOCK_NUM  	(8)		// maximum number of memory block  
 #define DENSE_WEIGHT_OPT 	(1)		// if used fully connected layer optimized weights. 
 
+// Backend format configuration
+//#define NNOM_USING_CHW            // uncomment if using CHW format. otherwise using default HWC format.
+                                    // Notes, CHW is incompatible with CMSIS-NN. 
+                                    // CHW must be used when using hardware accelerator such as KPU in K210 chip
+
+// Backend selection
 //#define NNOM_USING_CMSIS_NN       // uncomment if use CMSIS-NN for optimation 
+
 
 #endif
 

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -429,7 +429,8 @@ def generate_model(model, x_test, name='weights.h', format='hwc'):
             # FIXME: add more that could be skiped
             if('lambda' in layer.name or
                'dropout' in layer.name or
-               'batch_normalization' in layer.name): # flatten layer can be skipped in HWC but have to present in CHW
+               'batch_normalization' in layer.name or
+                ('flatten' in layer.name and 'chw' not in format)): # flatten layer can be skipped in HWC but have to present in CHW
                 return True
             return False
         for id,layer in enumerate(L):
@@ -588,7 +589,7 @@ def generate_model(model, x_test, name='weights.h', format='hwc'):
                         id,  cfg['cropping'][0], cfg['cropping'][1], LI[inp][0]))
 
             # others
-            elif('flatten' in layer.name and 'chw' in format): # flatten is needed in CHW backend but not needed in HWC
+            elif('flatten' in layer.name): # flatten is needed in CHW backend but not needed in HWC
                 inp = layer.input.name.replace(':', '/').split('/')[0]
                 fp.write('\tlayer[%s] = model.hook(Flatten(), layer[%s]);\n'%(id, LI[inp][0]))
             elif('concatenate' in layer.name):

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -182,7 +182,7 @@ def fuse_bn_to_conv(layer):
         # after that, the model will be destroyed.. need a better way to pass the new weight
         layer.set_weights([c_w, c_b])
 
-def generate_weights(model, name='weights.h', shift_list=None):
+def generate_weights(model, name='weights.h', format='hwc', shift_list=None):
     # Quantize weights to 8-bits using (min,max) and write to file
     f = open(name, 'w')
     f.close()
@@ -249,19 +249,28 @@ def generate_weights(model, name='weights.h', shift_list=None):
             var_name = var_name.replace(':', '_')
             with open(name, 'a') as f:
                 f.write('#define ' + var_name.upper() + ' {')
-
-            if (len(var_values.shape) == 3):  # 1D convolution layer weights
-                transposed_wts = np.transpose(var_values, (2, 0, 1))
-                #transposed_wts = var_values
-            elif (len(var_values.shape) > 2):  # 2D convolution layer weights
-                transposed_wts = np.transpose(var_values, (3, 0, 1, 2))
-            else:  # fully connected layer weights or biases of any layer
-                # test, use opt weight reorder
+            # CHW format
+            if ('chw' in format):
                 if "dense" in var_name and "kernel" in var_name:
                     transposed_wts = np.transpose(var_values)
-                    transposed_wts = convert_to_x4_q7_weights(np.reshape(transposed_wts ,(transposed_wts.shape[0], transposed_wts.shape[1], 1, 1)))
+                    transposed_wts = convert_to_x4_q7_weights(
+                        np.reshape(transposed_wts, (transposed_wts.shape[0], transposed_wts.shape[1], 1, 1)))
+                # all other kernels, bias stay the same
                 else:
-                    transposed_wts = np.transpose(var_values)
+                    transposed_wts = var_values
+            # HWC format
+            else:
+                if (len(var_values.shape) == 3):  # 1D convolution layer weights
+                    transposed_wts = np.transpose(var_values, (2, 0, 1))
+                elif (len(var_values.shape) == 4):  # 2D convolution layer weights
+                    transposed_wts = np.transpose(var_values, (3, 0, 1, 2))
+                else:  # fully connected layer weights or biases of any layer
+                    # test, use opt weight reorder
+                    if "dense" in var_name and "kernel" in var_name:
+                        transposed_wts = np.transpose(var_values)
+                        transposed_wts = convert_to_x4_q7_weights(np.reshape(transposed_wts ,(transposed_wts.shape[0], transposed_wts.shape[1], 1, 1)))
+                    else:
+                        transposed_wts = np.transpose(var_values)
 
             print("  reshape to:",transposed_wts.shape)
 
@@ -366,9 +375,9 @@ def layers_output_ranges(model, x_test):
     print("shift list", shift_list)
     return shift_list
 
-def generate_model(model, x_test, name='weights.h'):
+def generate_model(model, x_test, name='weights.h', format='hwc'):
     shift_list = layers_output_ranges(model, x_test)
-    generate_weights(model, name=name, shift_list=shift_list)
+    generate_weights(model, name=name, format=format, shift_list=shift_list)
     if(type(model.layers[0]) != InputLayer):
         L = [model.input] + model.layers
     else:
@@ -420,8 +429,7 @@ def generate_model(model, x_test, name='weights.h'):
             # FIXME: add more that could be skiped
             if('lambda' in layer.name or
                'dropout' in layer.name or
-               'batch_normalization' in layer.name or
-               'flatten' in layer.name):
+               'batch_normalization' in layer.name): # flatten layer can be skipped in HWC but have to present in CHW
                 return True
             return False
         for id,layer in enumerate(L):
@@ -477,7 +485,9 @@ def generate_model(model, x_test, name='weights.h'):
                     inshape = layer.input_shape[1:]
                 except:
                     inshape = layer.shape[1:]
-                if (len(inshape) == 2):  # 1-D input
+                if (len(inshape) == 1):  # 1-D input
+                    fp.write('\tlayer[%d] = Input(shape(%d,1,1), nnom_input_data);\n' % (id, inshape[0]))
+                elif (len(inshape) == 2):  # 1-D input
                     fp.write('\tlayer[%d] = Input(shape(1,%d,%d), nnom_input_data);\n' % (id, inshape[0], inshape[1]))
                 else:
                     fp.write('\tlayer[%d] = Input(shape%s, nnom_input_data);\n' % (id, inshape))
@@ -578,6 +588,9 @@ def generate_model(model, x_test, name='weights.h'):
                         id,  cfg['cropping'][0], cfg['cropping'][1], LI[inp][0]))
 
             # others
+            elif('flatten' in layer.name and 'chw' in format): # flatten is needed in CHW backend but not needed in HWC
+                inp = layer.input.name.replace(':', '/').split('/')[0]
+                fp.write('\tlayer[%s] = model.hook(Flatten(), layer[%s]);\n'%(id, LI[inp][0]))
             elif('concatenate' in layer.name):
                 inps = [input.name.replace(':','/').split('/')[0] for input in layer.input]
                 inX = ''

--- a/src/nnom_layers.c
+++ b/src/nnom_layers.c
@@ -731,7 +731,9 @@ nnom_layer_t *Concat(int8_t axis)
 		uint32_t shape_element_num = sizeof(nnom_shape_t) / sizeof(nnom_shape_data_t);
 		if (axis < 0)
 			axis = (shape_element_num + axis);
-		layer->axis = axis;
+		else if (axis >0)
+			axis = axis -1; // keras use axis start from 1. we are using 0, 1, 2 (check?)
+		layer->axis = axis; 
 	}
 
 	return (nnom_layer_t *)layer;

--- a/src/nnom_layers.c
+++ b/src/nnom_layers.c
@@ -592,7 +592,11 @@ nnom_layer_t *Flatten(void)
 	layer->comp_out_shape = flatten_out_shape;
 	// set buf state
 	in->type = LAYER_BUF_TEMP;
-	out->type = LAYER_BUF_NULL;
+	#ifdef NNOM_USING_CHW
+		out->type = LAYER_BUF_TEMP; // test for CHW format
+	#else
+		out->type = LAYER_BUF_NULL; 
+	#endif
 	// put in & out on the layer.
 	layer->in = io_init(layer, in);
 	layer->out = io_init(layer, out);

--- a/src/nnom_local.c
+++ b/src/nnom_local.c
@@ -186,7 +186,7 @@ void local_maxpool_q7_CHW(const q7_t *Im_in,           // input image
                     {
                         if (k_y >= 0 && k_x >= 0 && k_y < dim_im_in_y && k_x < dim_im_in_x)
                         {
-                            if (Im_in[i_ch_in + ch_im_in * (k_x + k_y * dim_im_in_x)] > max)
+                            if (Im_in[i_ch_in * dim_im_in_x * dim_im_in_y + (k_x + k_y * dim_im_in_x)] > max)
                             {
                                 max = Im_in[i_ch_in * dim_im_in_x * dim_im_in_y + (k_x + k_y * dim_im_in_x)];
                             }
@@ -512,23 +512,23 @@ void local_convolve_CHW_q7_nonsquare(const q7_t *Im_in,                         
 #else
                 conv_out = bias[i] << bias_shift;
 #endif
-                for (m = 0; m < dim_kernel_y; m++)
-                {
-                    for (n = 0; n < dim_kernel_x; n++)
-                    {
-                        // if-for implementation
-                        in_row = stride_y * j + m - padding_y;
-                        in_col = stride_x * k + n - padding_x;
-                        if (in_row >= 0 && in_col >= 0 && in_row < dim_im_in_y && in_col < dim_im_in_x)
-                        {
-                            for (l = 0; l < ch_im_in; l++)
-                            {
+				for (m = 0; m < dim_kernel_y; m++)
+				{
+					for (n = 0; n < dim_kernel_x; n++)
+					{
+						// if-for implementation
+						in_row = stride_y * j + m - padding_y;
+						in_col = stride_x * k + n - padding_x;
+						if (in_row >= 0 && in_col >= 0 && in_row < dim_im_in_y && in_col < dim_im_in_x)
+						{
+							for (l = 0; l < ch_im_in; l++)
+							{
 								conv_out += Im_in[(in_row * dim_im_in_x + in_col) + l * dim_im_in_x * dim_im_in_y] *
-									wt[(m * dim_kernel_x + n) * ch_im_in * ch_im_out + l * ch_im_in + i];
-                            }
-                        }
-                    }
-                }
+									wt[(m * dim_kernel_x + n) * ch_im_in * ch_im_out + l * ch_im_out + i];
+							}
+						}
+					}
+				}
                 Im_out[i * dim_im_out_x * dim_im_out_y + (j * dim_im_out_x + k)] = (q7_t)__NNOM_SSAT((conv_out >> out_shift), 8);
             }
         }

--- a/src/nnom_local.c
+++ b/src/nnom_local.c
@@ -21,19 +21,19 @@
 
 // modified from CMSIS-NN test_ref
 void local_avepool_q7_HWC(const q7_t *Im_in,           // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t padding_x,    // padding sizes
-                          const uint16_t padding_y,    // padding sizes
-                          const uint16_t stride_x,     // stride
-                          const uint16_t stride_y,     // stride
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // a buffer for local storage, NULL by now
-                          q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out)
 {
     int16_t i_ch_in, i_x, i_y;
     int16_t k_x, k_y;
@@ -64,19 +64,19 @@ void local_avepool_q7_HWC(const q7_t *Im_in,           // input image
 }
 
 void local_avepool_q7_CHW(const q7_t *Im_in,           // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t padding_x,    // padding sizes
-                          const uint16_t padding_y,    // padding sizes
-                          const uint16_t stride_x,     // stride
-                          const uint16_t stride_y,     // stride
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // a buffer for local storage, NULL by now
-                          q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out)
 {
     int16_t i_ch_in, i_x, i_y;
     int16_t k_x, k_y;
@@ -110,19 +110,19 @@ void local_avepool_q7_CHW(const q7_t *Im_in,           // input image
 
 // modified from CMSIS-NN test_ref
 void local_maxpool_q7_HWC(const q7_t *Im_in,           // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t padding_x,    // padding sizes
-                          const uint16_t padding_y,    // padding sizes
-                          const uint16_t stride_x,     // stride
-                          const uint16_t stride_y,     // stride
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // a buffer for local storage, NULL by now
-                          q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out)
 {
     int16_t i_ch_in, i_x, i_y;
     int16_t k_x, k_y;
@@ -154,19 +154,19 @@ void local_maxpool_q7_HWC(const q7_t *Im_in,           // input image
 }
 
 void local_maxpool_q7_CHW(const q7_t *Im_in,           // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t padding_x,    // padding sizes
-                          const uint16_t padding_y,    // padding sizes
-                          const uint16_t stride_x,     // stride
-                          const uint16_t stride_y,     // stride
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // a buffer for local storage, NULL by now
-                          q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out)
 {
     int16_t i_ch_in, i_x, i_y;
     int16_t k_x, k_y;
@@ -202,19 +202,19 @@ void local_maxpool_q7_CHW(const q7_t *Im_in,           // input image
 // temporary for the thesis
 // shift according to the maximum
 int32_t local_sumpool_q7_HWC(const q7_t *Im_in,           // input image
-                             const uint16_t dim_im_in_x,  // input image dimension x or W
-                             const uint16_t dim_im_in_y,  // input image dimension y or H
-                             const uint16_t ch_im_in,     // number of input image channels
-                             const uint16_t dim_kernel_x, // window kernel size
-                             const uint16_t dim_kernel_y, // window kernel size
-                             const uint16_t padding_x,    // padding sizes
-                             const uint16_t padding_y,    // padding sizes
-                             const uint16_t stride_x,     // stride
-                             const uint16_t stride_y,     // stride
-                             const uint16_t dim_im_out_x, // output image dimension x or W
-                             const uint16_t dim_im_out_y, // output image dimension y or H
-                             q7_t *bufferA,               // a buffer for local storage, size = 4*output_size
-                             q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, size = 4*output_size
+	q7_t *Im_out)
 {
     int16_t i_ch_in, i_x, i_y;
     int16_t k_x, k_y;
@@ -275,19 +275,19 @@ int32_t local_sumpool_q7_HWC(const q7_t *Im_in,           // input image
 // temporary for the thesis
 // shift according to the maximum
 int32_t local_sumpool_q7_CHW(const q7_t *Im_in,           // input image
-                             const uint16_t dim_im_in_x,  // input image dimension x or W
-                             const uint16_t dim_im_in_y,  // input image dimension y or H
-                             const uint16_t ch_im_in,     // number of input image channels
-                             const uint16_t dim_kernel_x, // window kernel size
-                             const uint16_t dim_kernel_y, // window kernel size
-                             const uint16_t padding_x,    // padding sizes
-                             const uint16_t padding_y,    // padding sizes
-                             const uint16_t stride_x,     // stride
-                             const uint16_t stride_y,     // stride
-                             const uint16_t dim_im_out_x, // output image dimension x or W
-                             const uint16_t dim_im_out_y, // output image dimension y or H
-                             q7_t *bufferA,               // a buffer for local storage, size = 4*output_size
-                             q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, size = 4*output_size
+	q7_t *Im_out)
 {
     int16_t i_ch_in, i_x, i_y;
     int16_t k_x, k_y;
@@ -351,22 +351,22 @@ int32_t local_sumpool_q7_CHW(const q7_t *Im_in,           // input image
 
 // customised up sample pooling
 void local_up_sampling_q7_HWC(const q7_t *Im_in,       // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // a buffer for local storage, NULL by now
-                          q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out)
 {
     int16_t i_x, i_y;
 	
     // for loop for each pixel in input image.
-    for (i_y = 0; i_y < dim_im_in_x; i_y++)
+    for (i_y = 0; i_y < dim_im_in_y; i_y++)
     {
-        for (i_x = 0; i_x < dim_im_in_y; i_x++)
+        for (i_x = 0; i_x < dim_im_in_x; i_x++)
         {
             // copy all the channels together. 
             const q7_t *p_in = Im_in + (i_y * dim_im_in_x + i_x ) * ch_im_in;
@@ -374,36 +374,36 @@ void local_up_sampling_q7_HWC(const q7_t *Im_in,       // input image
 
             // cpy along x axis
             for(int i = 0; i<dim_kernel_x; i++)
-                memcpy(pout + i*ch_im_in, p_in, ch_im_in);
+                memcpy(pout + i * ch_im_in, p_in, ch_im_in);
             // duplicate the copied x data into y axis. 
-            for(int i = 0; i<dim_kernel_y-1; i++)
-                memcpy(pout + (i+1) * ch_im_in * dim_im_in_x * dim_kernel_x, pout, ch_im_in * dim_kernel_x);
+            for(int i = 1; i<dim_kernel_y-1; i++)
+                memcpy(pout + i * ch_im_in * dim_im_in_x * dim_kernel_x, pout, ch_im_in * dim_kernel_x);
         }
     }
 }
 
 void local_up_sampling_q7_CHW(const q7_t *Im_in,       // input image
-                          const uint16_t dim_im_in_x,  // input image dimension x or W
-                          const uint16_t dim_im_in_y,  // input image dimension y or H
-                          const uint16_t ch_im_in,     // number of input image channels
-                          const uint16_t dim_kernel_x, // window kernel size
-                          const uint16_t dim_kernel_y, // window kernel size
-                          const uint16_t dim_im_out_x, // output image dimension x or W
-                          const uint16_t dim_im_out_y, // output image dimension y or H
-                          q7_t *bufferA,               // a buffer for local storage, NULL by now
-                          q7_t *Im_out)
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out)
 {
     int16_t i_x, i_y, ch;
 	// for loop for channel
 	for(ch=0; ch<ch_im_in; ch++)
 	{
 		// for loop for each pixel in input image.
-		for (i_y = 0; i_y < dim_im_in_x; i_y++)
+		for (i_y = 0; i_y < dim_im_in_y; i_y++)
 		{
-			for (i_x = 0; i_x < dim_im_in_y; i_x++)
+			for (i_x = 0; i_x < dim_im_in_x; i_x++)
 			{
-				const q7_t *p_in = Im_in + (i_y * dim_im_in_x + i_x ) + ch_im_in * dim_im_in_x * dim_im_in_y;
-				q7_t *pout = Im_out + (i_y * dim_im_in_x * dim_kernel_x * dim_kernel_y + i_x * dim_kernel_y) + ch_im_in * dim_im_out_x * dim_im_out_y;
+				const q7_t *p_in = Im_in + ch * dim_im_in_x * dim_im_in_y + (i_y * dim_im_in_x + i_x);
+				q7_t *pout = Im_out + ch * dim_im_out_x * dim_im_out_y + (i_y * dim_im_in_x * dim_kernel_x * dim_kernel_y + i_x * dim_kernel_y);
 
 				// cpy along x axis
 				for(int i = 0; i<dim_kernel_x; i++)
@@ -417,24 +417,24 @@ void local_up_sampling_q7_CHW(const q7_t *Im_in,       // input image
 }
 
 
-void local_convolve_HWC_q7_nonsquare(const q7_t *Im_in,                                                 // input image
-                                     const uint16_t dim_im_in_x,                                        // input image dimention x
-                                     const uint16_t dim_im_in_y,                                        // input image dimention y
-                                     const uint16_t ch_im_in,                                           // number of input image channels
-                                     const q7_t *wt,                                                    // kernel weights
-                                     const uint16_t ch_im_out,                                          // number of filters, i.e., output image channels
-                                     const uint16_t dim_kernel_x,                                       // filter kernel size x
-                                     const uint16_t dim_kernel_y,                                       // filter kernel size y
-                                     const uint16_t padding_x,                                          // padding sizes x
-                                     const uint16_t padding_y,                                          // padding sizes y
-                                     const uint16_t stride_x,                                           // stride x
-                                     const uint16_t stride_y,                                           // stride y
-                                     const q7_t *bias,                                                  // bias
-                                     const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, // output image
-                                     const uint16_t dim_im_out_x,                                       // output image dimension x
-                                     const uint16_t dim_im_out_y,                                       // output image dimension y
-                                     q15_t *bufferA,                                                    //buffer space for input
-                                     q7_t *bufferB                                                      //buffer space for output
+void local_convolve_HWC_q7_nonsquare(const q7_t *Im_in,                // input image
+	const uint16_t dim_im_in_x,                                        // input image dimention x
+	const uint16_t dim_im_in_y,                                        // input image dimention y
+	const uint16_t ch_im_in,                                           // number of input image channels
+	const q7_t *wt,                                                    // kernel weights
+	const uint16_t ch_im_out,                                          // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x,                                       // filter kernel size x
+	const uint16_t dim_kernel_y,                                       // filter kernel size y
+	const uint16_t padding_x,                                          // padding sizes x
+	const uint16_t padding_y,                                          // padding sizes y
+	const uint16_t stride_x,                                           // stride x
+	const uint16_t stride_y,                                           // stride y
+	const q7_t *bias,                                                  // bias
+	const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, // output image
+	const uint16_t dim_im_out_x,                                       // output image dimension x
+	const uint16_t dim_im_out_y,                                       // output image dimension y
+	q15_t *bufferA,                                                    //buffer space for input
+	q7_t *bufferB                                                      //buffer space for output
 )
 {
     int i, j, k, l, m, n;
@@ -477,24 +477,24 @@ void local_convolve_HWC_q7_nonsquare(const q7_t *Im_in,                         
 }
 
 
-void local_convolve_CHW_q7_nonsquare(const q7_t *Im_in,                                                 // input image
-                                     const uint16_t dim_im_in_x,                                        // input image dimention x
-                                     const uint16_t dim_im_in_y,                                        // input image dimention y
-                                     const uint16_t ch_im_in,                                           // number of input image channels
-                                     const q7_t *wt,                                                    // kernel weights
-                                     const uint16_t ch_im_out,                                          // number of filters, i.e., output image channels
-                                     const uint16_t dim_kernel_x,                                       // filter kernel size x
-                                     const uint16_t dim_kernel_y,                                       // filter kernel size y
-                                     const uint16_t padding_x,                                          // padding sizes x
-                                     const uint16_t padding_y,                                          // padding sizes y
-                                     const uint16_t stride_x,                                           // stride x
-                                     const uint16_t stride_y,                                           // stride y
-                                     const q7_t *bias,                                                  // bias
-                                     const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, // output image
-                                     const uint16_t dim_im_out_x,                                       // output image dimension x
-                                     const uint16_t dim_im_out_y,                                       // output image dimension y
-                                     q15_t *bufferA,                                                    //buffer space for input
-                                     q7_t *bufferB                                                      //buffer space for output
+void local_convolve_CHW_q7_nonsquare(const q7_t *Im_in,                // input image
+	const uint16_t dim_im_in_x,                                        // input image dimention x
+	const uint16_t dim_im_in_y,                                        // input image dimention y
+	const uint16_t ch_im_in,                                           // number of input image channels
+	const q7_t *wt,                                                    // kernel weights
+	const uint16_t ch_im_out,                                          // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x,                                       // filter kernel size x
+	const uint16_t dim_kernel_y,                                       // filter kernel size y
+	const uint16_t padding_x,                                          // padding sizes x
+	const uint16_t padding_y,                                          // padding sizes y
+	const uint16_t stride_x,                                           // stride x
+	const uint16_t stride_y,                                           // stride y
+	const q7_t *bias,                                                  // bias
+	const uint16_t bias_shift, const uint16_t out_shift, q7_t *Im_out, // output image
+	const uint16_t dim_im_out_x,                                       // output image dimension x
+	const uint16_t dim_im_out_y,                                       // output image dimension y
+	q15_t *bufferA,                                                    //buffer space for input
+	q7_t *bufferB                                                      //buffer space for output
 )
 {
     int i, j, k, l, m, n;
@@ -536,27 +536,26 @@ void local_convolve_CHW_q7_nonsquare(const q7_t *Im_in,                         
 }
 
 
-
 void local_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,           // input image
-                                                     const uint16_t dim_im_in_x,  // input image dimention x
-                                                     const uint16_t dim_im_in_y,  // input image dimention y
-                                                     const uint16_t ch_im_in,     // number of input image channels
-                                                     const q7_t *wt,              // kernel weights
-                                                     const uint16_t ch_im_out,    // number of filters, i.e., output image channels
-                                                     const uint16_t dim_kernel_x, // filter kernel size x
-                                                     const uint16_t dim_kernel_y, // filter kernel size y
-                                                     const uint16_t padding_x,    // padding sizes x
-                                                     const uint16_t padding_y,    // padding sizes y
-                                                     const uint16_t stride_x,     // stride x
-                                                     const uint16_t stride_y,     // stride y
-                                                     const q7_t *bias,            // bias
-                                                     const uint16_t bias_shift,   // amount of left-shift for bias
-                                                     const uint16_t out_shift,    // amount of right-shift for output
-                                                     q7_t *Im_out,                // output image
-                                                     const uint16_t dim_im_out_x, // output image dimension x
-                                                     const uint16_t dim_im_out_y, // output image dimension y
-                                                     q15_t *bufferA,              //buffer space for input
-                                                     q7_t *bufferB                //buffer space for output
+	const uint16_t dim_im_in_x,  // input image dimention x
+	const uint16_t dim_im_in_y,  // input image dimention y
+	const uint16_t ch_im_in,     // number of input image channels
+	const q7_t *wt,              // kernel weights
+	const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x, // filter kernel size x
+	const uint16_t dim_kernel_y, // filter kernel size y
+	const uint16_t padding_x,    // padding sizes x
+	const uint16_t padding_y,    // padding sizes y
+	const uint16_t stride_x,     // stride x
+	const uint16_t stride_y,     // stride y
+	const q7_t *bias,            // bias
+	const uint16_t bias_shift,   // amount of left-shift for bias
+	const uint16_t out_shift,    // amount of right-shift for output
+	q7_t *Im_out,                // output image
+	const uint16_t dim_im_out_x, // output image dimension x
+	const uint16_t dim_im_out_y, // output image dimension y
+	q15_t *bufferA,              //buffer space for input
+	q7_t *bufferB                //buffer space for output
 )
 {
     int i_out_y, i_out_x, i_ch_out;
@@ -593,17 +592,74 @@ void local_depthwise_separable_conv_HWC_q7_nonsquare(const q7_t *Im_in,         
     }
 }
 
+void local_depthwise_separable_conv_CHW_q7_nonsquare(const q7_t *Im_in,           // input image
+	const uint16_t dim_im_in_x,  // input image dimention x
+	const uint16_t dim_im_in_y,  // input image dimention y
+	const uint16_t ch_im_in,     // number of input image channels
+	const q7_t *wt,              // kernel weights
+	const uint16_t ch_im_out,    // number of filters, i.e., output image channels
+	const uint16_t dim_kernel_x, // filter kernel size x
+	const uint16_t dim_kernel_y, // filter kernel size y
+	const uint16_t padding_x,    // padding sizes x
+	const uint16_t padding_y,    // padding sizes y
+	const uint16_t stride_x,     // stride x
+	const uint16_t stride_y,     // stride y
+	const q7_t *bias,            // bias
+	const uint16_t bias_shift,   // amount of left-shift for bias
+	const uint16_t out_shift,    // amount of right-shift for output
+	q7_t *Im_out,                // output image
+	const uint16_t dim_im_out_x, // output image dimension x
+	const uint16_t dim_im_out_y, // output image dimension y
+	q15_t *bufferA,              //buffer space for input
+	q7_t *bufferB                //buffer space for output
+)
+{
+    int i_out_y, i_out_x, i_ch_out;
+    int i_ker_y, i_ker_x;
+	long conv_out;
+	for (i_ch_out = 0; i_ch_out < ch_im_out; i_ch_out++)
+	{
+		for (i_out_y = 0; i_out_y < dim_im_out_y; i_out_y++)
+		{
+			for (i_out_x = 0; i_out_x < dim_im_out_x; i_out_x++)
+			{
+#ifndef NNOM_TRUNCATE
+                conv_out = ((q31_t)(bias[i_ch_out]) << bias_shift) + (0x1 << (out_shift - 1));
+#else
+                conv_out = bias[i_ch_out] << bias_shift;
+#endif
+				for (i_ker_y = 0; i_ker_y < dim_kernel_y; i_ker_y++)
+				{
+					for (i_ker_x = 0; i_ker_x < dim_kernel_x; i_ker_x++)
+					{
+						// if-for implementation
+						int in_row = stride_y * i_out_y + i_ker_y - padding_y;
+						int in_col = stride_x * i_out_x + i_ker_x - padding_x;
+						if (in_row >= 0 && in_col >= 0 && in_row < dim_im_in_y && in_col < dim_im_in_x)
+						{
+							conv_out += Im_in[(in_row * dim_im_in_x + in_col) + i_ch_out * dim_im_in_x * dim_im_in_y] *
+								wt[(i_ker_y * dim_kernel_x + i_ker_x) * ch_im_out + i_ch_out];		
+						}
+					}
+				}
+                Im_out[i_ch_out * dim_im_out_x * dim_im_out_y + (i_out_y * dim_im_out_x + i_out_x)] = (q7_t)__NNOM_SSAT((conv_out >> out_shift), 8);
+            }
+        }
+    }
+}
+
+
 void local_zero_padding_HWC_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y)   // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y)   // output image dimension y 
 {
 	int i, size;
 	q7_t * p_out = Im_out; 
@@ -634,16 +690,16 @@ void local_zero_padding_HWC_q7(const q7_t *Im_in,           // input image
 }
 
 void local_zero_padding_CHW_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y)   // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y)   // output image dimension y 
 {
 	int i, size, ch_offset;
 	q7_t * p_out = Im_out; 
@@ -678,16 +734,16 @@ void local_zero_padding_CHW_q7(const q7_t *Im_in,           // input image
 
 
 void local_cropping_HWC_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y)   // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y)   // output image dimension y 
 {
 	int i, row_size;
 	const q7_t * p_in = Im_in; 
@@ -711,16 +767,16 @@ void local_cropping_HWC_q7(const q7_t *Im_in,           // input image
 }
 
 void local_cropping_CHW_q7(const q7_t *Im_in,           // input image
-						 const uint16_t dim_im_in_x,    // input image dimention x
-						 const uint16_t dim_im_in_y,    // input image dimention y
-						 const uint16_t ch_im_in,       // number of input image channels
-						 const uint16_t padding_top,    // padding sizes y
-						 const uint16_t padding_bottom, // padding sizes y
-						 const uint16_t padding_left,   // padding sizes x
-						 const uint16_t padding_right,  // padding sizes x
-						 q7_t *Im_out,                  // output image
-						 const uint16_t dim_im_out_x,   // output image dimension x
-						 const uint16_t dim_im_out_y)   // output image dimension y 
+	const uint16_t dim_im_in_x,    // input image dimention x
+	const uint16_t dim_im_in_y,    // input image dimention y
+	const uint16_t ch_im_in,       // number of input image channels
+	const uint16_t padding_top,    // padding sizes y
+	const uint16_t padding_bottom, // padding sizes y
+	const uint16_t padding_left,   // padding sizes x
+	const uint16_t padding_right,  // padding sizes x
+	q7_t *Im_out,                  // output image
+	const uint16_t dim_im_out_x,   // output image dimension x
+	const uint16_t dim_im_out_y)   // output image dimension y 
 {
 	int i, ch, ch_offset;
 	const q7_t * p_in; 
@@ -741,13 +797,13 @@ void local_cropping_CHW_q7(const q7_t *Im_in,           // input image
 }
 
 void local_fully_connected_q7_opt(const q7_t *pV,               // pointer to vector
-                                  const q7_t *pM,               // pointer to matrix
-                                  const uint16_t dim_vec,       // length of the vector
-                                  const uint16_t num_of_rows,   // numCol of A
-                                  const uint16_t bias_shift,    // amount of left-shift for bias
-                                  const uint16_t out_shift,     // amount of right-shift for output
-                                  const q7_t *bias, q7_t *pOut, // output operand
-                                  q15_t *vec_buffer)
+	const q7_t *pM,               // pointer to matrix
+	const uint16_t dim_vec,       // length of the vector
+	const uint16_t num_of_rows,   // numCol of A
+	const uint16_t bias_shift,    // amount of left-shift for bias
+	const uint16_t out_shift,     // amount of right-shift for output
+	const q7_t *bias, q7_t *pOut, // output operand
+	q15_t *vec_buffer)
 {
 
     uint16_t rowCnt = num_of_rows >> 2;
@@ -860,13 +916,13 @@ void local_fully_connected_q7_opt(const q7_t *pV,               // pointer to ve
 }
 
 void local_fully_connected_q7(const q7_t *pV,               // pointer to vector
-                              const q7_t *pM,               // pointer to matrix
-                              const uint16_t dim_vec,       // length of the vector
-                              const uint16_t num_of_rows,   // numCol of A
-                              const uint16_t bias_shift,    // amount of left-shift for bias
-                              const uint16_t out_shift,     // amount of right-shift for output
-                              const q7_t *bias, q7_t *pOut, // output operand
-                              q15_t *vec_buffer)
+	const q7_t *pM,               // pointer to matrix
+	const uint16_t dim_vec,       // length of the vector
+	const uint16_t num_of_rows,   // numCol of A
+	const uint16_t bias_shift,    // amount of left-shift for bias
+	const uint16_t out_shift,     // amount of right-shift for output
+	const q7_t *bias, q7_t *pOut, // output operand
+	q15_t *vec_buffer)
 {
     for (int i = 0; i < num_of_rows; i++)
     {

--- a/src/nnom_run.c
+++ b/src/nnom_run.c
@@ -57,10 +57,11 @@ void hwc2chw_q7(nnom_shape_t shape, q7_t* p_in, q7_t* p_out)
 void chw2hwc_q7(nnom_shape_t shape, q7_t* p_in, q7_t* p_out)
 {
 	int im_size = shape.w * shape.h;
+	int h_step;
 	
 	for(int h=0; h<shape.h; h++)
 	{
-		int h_step = shape.w * h;
+		h_step = shape.w * h;
 		for(int w=0; w<shape.w; w++)
 		{
 			for(int c=0; c<shape.c; c++)
@@ -70,7 +71,6 @@ void chw2hwc_q7(nnom_shape_t shape, q7_t* p_in, q7_t* p_out)
 			}
 		}
 	}
-
 }
 
 nnom_status_t flatten_run(nnom_layer_t *layer)
@@ -246,7 +246,7 @@ nnom_status_t cropping_run(nnom_layer_t * layer)
 	nnom_cropping_layer_t *cl = (nnom_cropping_layer_t*)layer;
 	
 #ifdef NNOM_USING_CHW
-	local_cropping_HWC_q7(
+	local_cropping_CHW_q7(
 #else
 	local_cropping_HWC_q7(
 #endif	


### PR DESCRIPTION
CMSIS-NN and previous local backend is working on HWC for CPU acceleration.
However, AI chips such as K210's KPU is working in CHW format which is similar to most ML lib on the PC. A support for CHW format will let NNoM benefit for the hardware convolutions.

Depthwise Conv, Up Sampling in CHW, rebuild Concat for CHW and HWC

This commit add the CHW version to the below operators.
- Cropping
- Zero Padding
- Max, Avg, Sum pooling
- Up Sampling
- Conv, Depthwise Conv
- Dense
Layers not affected (originally support both formats)
- Add, sub, mult
- All activations