### PR TITLE
Implement KLD method for activation quantisation

### DIFF
--- a/examples/mnist-densenet/model/mnist_densenet.py
+++ b/examples/mnist-densenet/model/mnist_densenet.py
@@ -146,7 +146,7 @@ def main(weights='weights.h'):
                 out = np.asarray(out)
                 num, prop = out.argmax(), out[out.argmax()]
                 rnum = y_test[i].argmax()
-                if((rnum == num) and (prop > 0.8)):
+                if(rnum == num):
                     #print('test image %d is %d, predict correctly with prop %s'%(i, rnum, prop))
                     rP += 1.0
                 if((i>0) and ((i%1000)==0)):

--- a/inc/nnom_layers.h
+++ b/inc/nnom_layers.h
@@ -134,6 +134,7 @@ typedef struct _nnom_maxpool_layer_t
 	nnom_shape_t stride;
 	nnom_shape_t pad;
 	nnom_padding_t padding_type;
+	int16_t output_shift;			// reserve
 } nnom_maxpool_layer_t;
 
 // Avg Pooling

--- a/inc/nnom_local.h
+++ b/inc/nnom_local.h
@@ -58,35 +58,37 @@ static inline int __NNOM_USAT(int32_t value, int32_t bit) {
 // Those functions/tables below are partially modifed from CMSIS-NN lib
 // https://github.com/ARM-software/CMSIS_5
 //
-void local_avepool_q7_HWC(const q7_t * Im_in, // input image
-	const uint16_t dim_im_in_x,   	// input image dimension x or W
-	const uint16_t dim_im_in_y,   	// input image dimension y or H
-	const uint16_t ch_im_in,    	// number of input image channels
-	const uint16_t dim_kernel_x,  	// window kernel size
-	const uint16_t dim_kernel_y,  	// window kernel size
-	const uint16_t padding_x, 		// padding sizes
-	const uint16_t padding_y, 		// padding sizes
-	const uint16_t stride_x,  		// stride
-	const uint16_t stride_y,  		// stride
-	const uint16_t dim_im_out_x,  	// output image dimension x or W
-	const uint16_t dim_im_out_y,  	// output image dimension y or H
-	q7_t * bufferA, 				// a buffer for local storage, NULL by now
-	q7_t * Im_out);
+void local_avepool_q7_HWC(const q7_t *Im_in,           // input image
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	const uint16_t output_shift, // output right shift
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out);
 
-void local_avepool_q7_CHW(const q7_t * Im_in, // input image
-	const uint16_t dim_im_in_x,   	// input image dimension x or W
-	const uint16_t dim_im_in_y,   	// input image dimension y or H
-	const uint16_t ch_im_in,    	// number of input image channels
-	const uint16_t dim_kernel_x,  	// window kernel size
-	const uint16_t dim_kernel_y,  	// window kernel size
-	const uint16_t padding_x, 		// padding sizes
-	const uint16_t padding_y, 		// padding sizes
-	const uint16_t stride_x,  		// stride
-	const uint16_t stride_y,  		// stride
-	const uint16_t dim_im_out_x,  	// output image dimension x or W
-	const uint16_t dim_im_out_y,  	// output image dimension y or H
-	q7_t * bufferA, 				// a buffer for local storage, NULL by now
-	q7_t * Im_out);
+void local_avepool_q7_CHW(const q7_t *Im_in,           // input image
+	const uint16_t dim_im_in_x,  // input image dimension x or W
+	const uint16_t dim_im_in_y,  // input image dimension y or H
+	const uint16_t ch_im_in,     // number of input image channels
+	const uint16_t dim_kernel_x, // window kernel size
+	const uint16_t dim_kernel_y, // window kernel size
+	const uint16_t padding_x,    // padding sizes
+	const uint16_t padding_y,    // padding sizes
+	const uint16_t stride_x,     // stride
+	const uint16_t stride_y,     // stride
+	const uint16_t dim_im_out_x, // output image dimension x or W
+	const uint16_t dim_im_out_y, // output image dimension y or H
+	const uint16_t output_shift, // output right shift
+	q7_t *bufferA,               // a buffer for local storage, NULL by now
+	q7_t *Im_out);
 
 // modified from CMSIS-NN test_ref                            
 void local_maxpool_q7_HWC(const q7_t * Im_in, 				// input image

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -185,6 +185,7 @@ def fuse_bn_to_conv(layer):
 def generate_weights(model, name='weights.h', format='hwc', shift_list=None):
     # Quantize weights to 8-bits using (min,max) and write to file
     f = open(name, 'w')
+    f.write('#include "nnom.h"\n\n')
     f.close()
 
     for curr_idx, layer in  enumerate(model.layers):

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -296,6 +296,7 @@ def generate_weights(model, name='weights.h', format='hwc', shift_list=None):
 
 def layers_output_ranges(model, x_test, kld=True, calibrate_size=1000):
     # limit the test data size
+    x_test = np.random.shuffle(x_test)
     if(x_test.shape[0] > calibrate_size):
         x_test = x_test[:1000]
     # test, show the output ranges

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -294,7 +294,10 @@ def generate_weights(model, name='weights.h', format='hwc', shift_list=None):
                   ' min: (' + str(np.min(var_values)) + ',' + str(min_value) + ')')
             """
 
-def layers_output_ranges(model, x_test):
+def layers_output_ranges(model, x_test, kld=True, calibrate_size=1000):
+    # limit the test data size
+    if(x_test.shape[0] > calibrate_size):
+        x_test = x_test[:1000]
     # test, show the output ranges
     shift_list = {}
     # FIXME: only support one input
@@ -303,27 +306,71 @@ def layers_output_ranges(model, x_test):
     else:
         L = model.layers
     last_layer = None
-    for layer in L:
+
+    for layer in L: # layer loop
         if("input" in layer.name):
             features = x_test
         else:
-            # batch_normalization will need to be handle differently, since we are fusing the weight to its predecessor.
+            # batch_normalization will need to be handled differently, since we are fusing the weight to its predecessor.
             # sigmoid and tanh are different, their shift is fixed to 7
             if(is_shift_layer(layer) or
                 ('batch_normalization' in layer.name) or
                 ('activation' in layer.name and layer.get_config()['activation'] == 'sigmoid') or
                 ('activation' in layer.name and layer.get_config()['activation'] == 'tanh')):
                 layer_model = Model(inputs=model.input, outputs=layer.output)
-                # FIXME, when the test data is too large, it might return memory error. need to slice data into small pices
                 features = layer_model.predict(x_test)
             else:
                 # leave the features not changed, so this layer shift will be the same
                 # as its inputs
                 pass
+        #  no saturation shift
         max_val = features.max()
         min_val = features.min()
         int_bits = int(np.ceil(np.log2(max(abs(max_val), abs(min_val)))))
         dec_bits = 7 - int_bits
+
+        # saturation shift, using KLD method
+        # Ref: http://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf
+        if(kld):
+            import scipy.stats
+            abs_max = max(abs(max_val), abs(min_val))
+            small_var = 1e-5
+            bins = np.arange(-abs_max, abs_max, abs_max/2048*2)
+            q_bins = np.arange(-abs_max, abs_max, abs_max/256*2)
+            flat_hist = np.histogram(features.flatten(), bins=bins)[0]
+            kl_list = []
+            kl_shifts = []
+            for shift in range(8):
+                t = 2 ** (dec_bits + shift)     # 2-based threshold
+                act = np.round(features.flatten() * t)
+                act = act / t
+                act = np.clip(act, -128/t, 127/t)
+                act = np.histogram(act, bins=q_bins)[0]
+                act_hist = np.zeros(2047)
+                chunk = int(2048/256)
+                for i in range(int(255)):
+                    none_zero = np.count_nonzero(flat_hist[i*chunk:(i+1)*chunk])
+                    if none_zero == 0:
+                        continue
+                    for j in range(chunk):
+                        act_hist[i*chunk+j] = act[i]/none_zero if flat_hist[i*chunk+j] != 0 else 0
+                flat_hist[flat_hist==0] = small_var
+                act_hist[act_hist==0] = small_var
+                kl = scipy.stats.entropy(flat_hist, act_hist)
+                kl_list.append(kl)
+                kl_shifts.append(dec_bits + shift)
+                """
+                ax = plt.subplot(8, 1, shift+1)
+                ax.plot(flat_hist)
+                ax.plot(act_hist)
+                """
+            new_dec = kl_shifts[np.argmin(kl_list)] # set the dec_bit to the KLD results
+            #plt.show()
+            print("KLD lost", kl_list)
+            print("KLD shift", kl_shifts)
+            if(new_dec != dec_bits):
+                print("Quantisation of this layer using KLD method, original shift",dec_bits, "KLD results", new_dec)
+                dec_bits = new_dec
         print( layer.name, "max value:", max_val, "min value:", min_val,"dec bit", dec_bits)
         # record the shift
         if(model.input == layer and type(model.layers[0]) != InputLayer):
@@ -333,6 +380,7 @@ def layers_output_ranges(model, x_test):
         if ('batch_normalization' in layer.name):
             shift_list[last_layer.name] = dec_bits  # use the bn layer shift to update the last layer.
         last_layer = layer
+
     LM = {}
     for layer in model.layers:
         LM[layer.name] = layer
@@ -376,8 +424,8 @@ def layers_output_ranges(model, x_test):
     print("shift list", shift_list)
     return shift_list
 
-def generate_model(model, x_test, name='weights.h', format='hwc'):
-    shift_list = layers_output_ranges(model, x_test)
+def generate_model(model, x_test, name='weights.h', format='hwc', kld=True):
+    shift_list = layers_output_ranges(model, x_test, kld)
     generate_weights(model, name=name, format=format, shift_list=shift_list)
     if(type(model.layers[0]) != InputLayer):
         L = [model.input] + model.layers

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -296,7 +296,7 @@ def generate_weights(model, name='weights.h', format='hwc', shift_list=None):
 
 def layers_output_ranges(model, x_test, kld=True, calibrate_size=1000):
     # limit the test data size
-    x_test = np.random.shuffle(x_test)
+    np.random.shuffle(x_test)
     if(x_test.shape[0] > calibrate_size):
         x_test = x_test[:1000]
     # test, show the output ranges

--- a/scripts/nnom_utils.py
+++ b/scripts/nnom_utils.py
@@ -339,7 +339,7 @@ def layers_output_ranges(model, x_test, kld=True, calibrate_size=1000):
             bins = np.arange(-abs_max, abs_max, abs_max/2048*2)
             q_bins = np.arange(-abs_max, abs_max, abs_max/256*2)
             flat_hist = np.histogram(features.flatten(), bins=bins)[0]
-            kl_list = []
+            kl_loss = []
             kl_shifts = []
             for shift in range(8):
                 t = 2 ** (dec_bits + shift)     # 2-based threshold
@@ -358,19 +358,19 @@ def layers_output_ranges(model, x_test, kld=True, calibrate_size=1000):
                 flat_hist[flat_hist==0] = small_var
                 act_hist[act_hist==0] = small_var
                 kl = scipy.stats.entropy(flat_hist, act_hist)
-                kl_list.append(kl)
+                kl_loss.append(kl)
                 kl_shifts.append(dec_bits + shift)
                 """
                 ax = plt.subplot(8, 1, shift+1)
                 ax.plot(flat_hist)
                 ax.plot(act_hist)
                 """
-            new_dec = kl_shifts[np.argmin(kl_list)] # set the dec_bit to the KLD results
+            new_dec = kl_shifts[np.argmin(kl_loss)] # set the dec_bit to the KLD results
             #plt.show()
-            print("KLD lost", kl_list)
+            print("KLD loss", kl_loss)
             print("KLD shift", kl_shifts)
             if(new_dec != dec_bits):
-                print("Quantisation of this layer using KLD method, original shift",dec_bits, "KLD results", new_dec)
+                print("Layer:",layer.name,"using KLD method, original shift",dec_bits, "KLD results", new_dec)
                 dec_bits = new_dec
         print( layer.name, "max value:", max_val, "min value:", min_val,"dec bit", dec_bits)
         # record the shift

--- a/src/nnom_local.c
+++ b/src/nnom_local.c
@@ -32,6 +32,7 @@ void local_avepool_q7_HWC(const q7_t *Im_in,           // input image
 	const uint16_t stride_y,     // stride
 	const uint16_t dim_im_out_x, // output image dimension x or W
 	const uint16_t dim_im_out_y, // output image dimension y or H
+	const uint16_t output_shift, // output right shift
 	q7_t *bufferA,               // a buffer for local storage, NULL by now
 	q7_t *Im_out)
 {
@@ -57,7 +58,7 @@ void local_avepool_q7_HWC(const q7_t *Im_in,           // input image
                         }
                     }
                 }
-                Im_out[i_ch_in + ch_im_in * (i_x + i_y * dim_im_out_x)] = sum / count;
+                Im_out[i_ch_in + ch_im_in * (i_x + i_y * dim_im_out_x)] = sum / (count>>output_shift);
             }
         }
     }
@@ -75,6 +76,7 @@ void local_avepool_q7_CHW(const q7_t *Im_in,           // input image
 	const uint16_t stride_y,     // stride
 	const uint16_t dim_im_out_x, // output image dimension x or W
 	const uint16_t dim_im_out_y, // output image dimension y or H
+	const uint16_t output_shift, // output right shift
 	q7_t *bufferA,               // a buffer for local storage, NULL by now
 	q7_t *Im_out)
 {
@@ -102,7 +104,7 @@ void local_avepool_q7_CHW(const q7_t *Im_in,           // input image
                         }
                     }
                 }
-                Im_out[i_ch_in*dim_im_out_x*dim_im_out_y + (i_x + i_y * dim_im_out_x)] = sum / count;
+                Im_out[i_ch_in*dim_im_out_x*dim_im_out_y + (i_x + i_y * dim_im_out_x)] = sum / (count>>output_shift);
             }
         }
     }

--- a/src/nnom_run.c
+++ b/src/nnom_run.c
@@ -456,13 +456,15 @@ nnom_status_t avgpool_run(nnom_layer_t *layer)
 			cl->pad.w, cl->pad.h,
 			cl->stride.w, cl->stride.h,
 			layer->out->shape.w, layer->out->shape.h,
+			cl->output_shift,
 			NULL,
 			layer->out->mem->blk);
 #else //end of CHW
 	#ifdef NNOM_USING_CMSIS_NN
 	// 2D, square
 	if (layer->in->shape.w == layer->in->shape.h &&
-		layer->out->shape.w == layer->out->shape.h)
+		layer->out->shape.w == layer->out->shape.h &&
+		cl->output_shift == 0)
 	{
 		arm_avepool_q7_HWC(
 			layer->in->mem->blk,
@@ -483,6 +485,7 @@ nnom_status_t avgpool_run(nnom_layer_t *layer)
 				cl->pad.w, cl->pad.h,
 				cl->stride.w, cl->stride.h,
 				layer->out->shape.w, layer->out->shape.h,
+				cl->output_shift,
 				NULL,
 				layer->out->mem->blk);
 	}


### PR DESCRIPTION
The previous activation quantisation is non-saturation, the Q format of the layer output is defined by the maximum absolute value.  It guarantees that no value is saturated. So-call non-saturated method. 

KLD method is more aggressive in selecting Q-format to have better resolution for most data but also allow some values to be satuatied.  So-called saturation method. 

Details:
http://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf

There are some differences between the method in TensorRT and NNoM
TensorRT supports continual scaling factor while NNoM and other libs (CMSIS-NN / kpu in K210) only support the number which is the power of 2.
So instead of checking saturation from 128th to 2048th, we only check 8 shifts starts from the non-saturated shift. 