### PR TITLE
Fix bugs in sigmoid/tanh, add support for single neural as final output

### DIFF
--- a/examples/auto_test/README.md
+++ b/examples/auto_test/README.md
@@ -68,7 +68,7 @@ model = build_model(x_test.shape[1:])
 train(model, x_train,y_train, x_test, y_test, epochs=epochs)
 ~~~
 
-We first load the MNIST dataset (if it is the first time, Keras will download the dataset for you), then scales them int to a range of 0~1 by dividing 255. (MNIST dataset is 28 x 28 x 8bit grey scale image). Instead of 0~255, now images are represented by 0~1. Then build the model and train it the same way as most of the other tutorials you can find online. This section will finally save the trained model in our working directory.
+We first load the MNIST dataset (if it is the first time, Keras will download the dataset for you), then scales them int to a range of 0 ~ 1 by dividing 255. (MNIST dataset is 28 x 28 x 8bit grey scale image). Instead of 0 ~ 255, now images are represented by 0 ~ 1. Then build the model and train it the same way as most of the other tutorials you can find online. This section will finally save the trained model in our working directory.
 
 If you are not familiar with Keras model, you can check the “build_model()” in “main.py” for detail. This example shows a simple feed-forward model, however, complex models will be the same.
 

--- a/examples/auto_test/main.c
+++ b/examples/auto_test/main.c
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
 	printf("validation size: %d\n", (int)size); 
 	
 	model = nnom_model_create();				// create NNoM model
-	pre = prediction_create(model, nnom_output_data, 10, 4); // mnist, 10 classes, get top-4
+	pre = prediction_create(model, nnom_output_data, sizeof(nnom_output_data), 4); // mnist, 10 classes, get top-4
 	
 	// now takes label and data from the file and data
 	for(size_t seek=0; seek < size;)

--- a/examples/auto_test/main.c
+++ b/examples/auto_test/main.c
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
 	pre = prediction_create(model, nnom_output_data, 10, 4); // mnist, 10 classes, get top-4
 	
 	// now takes label and data from the file and data
-	for(int seek=0; seek < size;)
+	for(size_t seek=0; seek < size;)
 	{
 		// labels
 		uint8_t true_label[128];
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 			// save results
 			fprintf(fp, "%d,%f\n", label, prob);
 		}
-		printf("Processing %d%%\n", seek*100 / size);
+		printf("Processing %d%%\n", seek * 100 / size);
 	}
 
 	// print prediction result

--- a/examples/auto_test/main.py
+++ b/examples/auto_test/main.py
@@ -147,9 +147,9 @@ def main():
         # get NNoM results
         result = np.genfromtxt('result.csv', delimiter=',', skip_header=1)
         result = result[:,0]        # the first column is the label, the second is the probability
-        label = y_test_original     # use the original numerical label
+        label = y_test_original.flatten()     # use the original numerical label
         acc = np.sum(result == label).astype('float32')/len(result)
-        if (acc > 0.8):
+        if (acc > 0.5):
             print("Top 1 Accuracy on Keras %.2f%%" %(scores[1]*100))
             print("Top 1 Accuracy on NNoM  %.2f%%" %(acc *100))
             return 0

--- a/inc/nnom_local.h
+++ b/inc/nnom_local.h
@@ -326,10 +326,10 @@ void local_fully_connected_q7(const q7_t * pV,    // pointer to vector
 void local_softmax_q7(const q7_t * vec_in, const uint32_t dim_vec, q7_t * p_out);
 
 // sigmoid
-void local_sigmoid_q7(q7_t * data, uint32_t size, uint16_t int_width);
+void local_sigmoid_q7(q7_t * data, uint32_t size, int16_t int_width);
 
 // tanh
-void local_tanh_q7(q7_t * data, uint32_t size, uint16_t int_width);
+void local_tanh_q7(q7_t * data, uint32_t size, int16_t int_width);
 
 // relu
 void local_relu_q7(q7_t * data, uint32_t size);

--- a/src/nnom_local.c
+++ b/src/nnom_local.c
@@ -1000,7 +1000,7 @@ void local_softmax_q7(const q7_t *vec_in, const uint32_t dim_vec, q7_t *p_out)
     }
 }
 
-void local_sigmoid_q7(q7_t *data, uint32_t size, uint16_t int_width)
+void local_sigmoid_q7(q7_t * data, uint32_t size, int16_t int_width)
 {
     uint32_t i = size;
     q7_t *pIn = data;
@@ -1033,7 +1033,7 @@ void local_sigmoid_q7(q7_t *data, uint32_t size, uint16_t int_width)
     }
 }
 
-void local_tanh_q7(q7_t *data, uint32_t size, uint16_t int_width)
+void local_tanh_q7(q7_t *data, uint32_t size, int16_t int_width)
 {
     uint32_t i = size;
     q7_t *pIn = data;


### PR DESCRIPTION
- Fixed bugs in sigmoid tanh when decimal bit of the input lager than 7. This is due to the previous int_width is unsigned while it can be nagtive in decimal > 7.
- nnom_utils.py now support single label as input.
- Add supports for single neural output in `nnom_predict()` and `prediction_run()`.  prob = neural /127. When prob>= 0.5, label = 1, when prob < 0.5, label = 0. Nagtive neural is not support, the result is unknown.