### PR TITLE
resolve gnu reorder error

### DIFF
--- a/scripts/gen_config.py
+++ b/scripts/gen_config.py
@@ -398,8 +398,8 @@ def gen_rnn_config(layer):
     c = '''
 const nnom_rnn_config_t <layer_name>_config = {
     .super = <base_config>,
-    .stateful = <stateful>,
     .return_sequence = <return_sequence>,
+    .stateful = <stateful>,
     .go_backwards = <go_backwards>
 };
 '''


### PR DESCRIPTION
Encountered error below when exported header file is included in a C++ project.
```
error: designator order for field '_nnom_rnn_config_t::return_sequence' does not match declaration order in 'const nnom_rnn_config_t' {aka 'const _nnom_rnn_config_t'}
 };
 ^
```
Plus, adding a `-Wno-reorder` flag doesn't resolve this problem. 
Compiler: MinGW-W64 8.1.0