### PR TITLE
Resolving MFCC results in C vs. Python Mismatch and Creating PC test for the KWS Example

### DIFF
--- a/examples/keyword_spotting/README.md
+++ b/examples/keyword_spotting/README.md
@@ -164,8 +164,33 @@ Total Memory cost (Network and NNoM): 15020
 msh > 
 ~~~
 
+## Testing it on PC
+Now, you can test your KWS model on PC using KWS test data to be preprocessed by the C MFCC implementation. First, you need to download the raw test data from Google Drive [here](https://drive.google.com/drive/folders/1gS2klWb02YvaoE5UTNDy9SQsS5ZTsvNN?usp=sharing). Then, replace the main_pc.c to be you main file. It will print the model predictions followed by the groundtruth, and will also calculate the Top-1 accuracy score every 100 samples.
 
-
+~~~
+0 right : 100% - Ground Truth is: right
+1 nine : 100% - Ground Truth is: right
+2 right : 100% - Ground Truth is: right
+3 right : 100% - Ground Truth is: right
+4 right : 100% - Ground Truth is: right
+5 right : 100% - Ground Truth is: right
+6 right : 100% - Ground Truth is: right
+7 right : 100% - Ground Truth is: right
+8 right : 100% - Ground Truth is: right
+9 forward : 66% - Ground Truth is: right
+10 right : 100% - Ground Truth is: right
+11 right : 100% - Ground Truth is: right
+12 right : 100% - Ground Truth is: right
+13 right : 100% - Ground Truth is: right
+14 right : 52% - Ground Truth is: right
+15 right : 100% - Ground Truth is: right
+16 right : 100% - Ground Truth is: right
+17 right : 100% - Ground Truth is: right
+18 right : 100% - Ground Truth is: right
+19 right : 74% - Ground Truth is: right
+20 right : 100% - Ground Truth is: right
+...
+~~~
 
 
 

--- a/examples/keyword_spotting/main_pc.c
+++ b/examples/keyword_spotting/main_pc.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2018-2020, Jianjia Ma
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2019-03-29     Jianjia Ma   first implementation
+ *
+ * Notes:
+ * This is a keyword spotting example using NNoM
+ *
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "nnom.h"
+#include "kws_weights.h"
+
+#include "mfcc.h"
+#include "math.h"
+
+
+// NNoM model
+nnom_model_t *model;
+
+// 10 labels-1
+//const char label_name[][10] =  {"yes", "no", "up", "down", "left", "right", "on", "off", "stop", "go", "unknow"};
+
+// 10 labels-2
+//const char label_name[][10] =  {"marvin", "sheila", "yes", "no", "left", "right", "forward", "backward", "stop", "go", "unknow"};
+
+// full 34 labels
+const char label_name[][10] =  {"backward", "bed", "bird", "cat", "dog", "down", "eight","five", "follow", "forward",
+                      "four", "go", "happy", "house", "learn", "left", "marvin", "nine", "no", "off", "on", "one", "right",
+                      "seven", "sheila", "six", "stop", "three", "tree", "two", "up", "visual", "yes", "zero", "unknow"};
+
+
+
+int16_t audio[512];
+char ground_truth[12000][10];
+#define SAMP_FREQ 16000
+#define AUDIO_FRAME_LEN (512) //31.25ms * 16000hz = 512, // FFT (windows size must be 2 power n)
+
+mfcc_t * mfcc;
+//int32_t audio_data[4000]; //32000/8
+int dma_audio_buffer[AUDIO_FRAME_LEN]; //512
+int16_t audio_buffer_16bit[(int)(AUDIO_FRAME_LEN*1.5)]; // an easy method for 50% overlapping
+int audio_sample_i = 0;
+
+//the mfcc feature for kws
+#define MFCC_LEN            (62)
+#define MFCC_COEFFS_FIRST   (1)     // ignore the mfcc feature before this number
+#define MFCC_COEFFS_LEN     (13)    // the total coefficient to calculate
+#define MFCC_TOTAL_NUM_BANK (26)    // total number of filter bands
+#define MFCC_COEFFS         (MFCC_COEFFS_LEN-MFCC_COEFFS_FIRST)
+
+#define MFCC_FEAT_SIZE  (MFCC_LEN * MFCC_COEFFS)
+float mfcc_features_f[MFCC_COEFFS];             // output of mfcc
+int8_t mfcc_features[MFCC_LEN][MFCC_COEFFS];     // ring buffer
+int8_t mfcc_features_seq[MFCC_LEN][MFCC_COEFFS]; // sequencial buffer for neural network input.
+uint32_t mfcc_feat_index = 0;
+
+// msh debugging controls
+bool is_print_abs_mean = false; // to print the mean of absolute value of the mfcc_features_seq[][]
+bool is_print_mfcc  = false;    // to print the raw mfcc features at each update
+void Error_Handler()
+{
+    printf("error\n");
+}
+
+static int32_t abs_mean(int8_t *p, size_t size)
+{
+    int64_t sum = 0;
+    for(size_t i = 0; i<size; i++)
+    {
+        if(p[i] < 0)
+            sum+=-p[i];
+        else
+            sum += p[i];
+    }
+    return sum/size;
+}
+
+void quantize_data(float*din, int8_t *dout, uint32_t size, uint32_t int_bit)
+{
+    #define _MAX(x, y) (((x) > (y)) ? (x) : (y))
+    #define _MIN(x, y) (((x) < (y)) ? (x) : (y))
+    float limit = (1 << int_bit);
+    float d;
+    for(uint32_t i=0; i<size; i++)
+    {
+        d = round(_MAX(_MIN(din[i], limit), -limit) / limit * 128);
+        d = d/128.0f;
+        dout[i] = round(d *127);
+    }
+}
+
+
+
+void thread_kws_serv()
+{
+
+    #define SaturaLH(N, L, H) (((N)<(L))?(L):(((N)>(H))?(H):(N)))
+    int *p_raw_audio;
+
+
+    // calculate 13 coefficient, use number #2~13 coefficient. discard #1
+    // features, offset, bands, 512fft, 0 preempha, attached_energy_to_band0
+    mfcc = mfcc_create(MFCC_COEFFS_LEN, MFCC_COEFFS_FIRST, MFCC_TOTAL_NUM_BANK, AUDIO_FRAME_LEN, 0.97f, true);
+
+        if (audio_sample_i == 15872)
+            memset(&dma_audio_buffer[128], 0, sizeof(int) * 128); //to fill the latest quarter in the latest frame
+        p_raw_audio = dma_audio_buffer;
+
+
+        // memory move
+        // audio buffer = | 256 byte old data |   256 byte new data 1 | 256 byte new data 2 |
+        //                         ^------------------------------------------|
+        memcpy(audio_buffer_16bit, &audio_buffer_16bit[AUDIO_FRAME_LEN], (AUDIO_FRAME_LEN/2)*sizeof(int16_t));
+
+        // convert it to 16 bit.
+        // volume*4
+        for(int i = 0; i < AUDIO_FRAME_LEN; i++)
+        {
+            audio_buffer_16bit[AUDIO_FRAME_LEN/2+i] = p_raw_audio[i];
+        }
+
+        // MFCC
+        // do the first mfcc with half old data(256) and half new data(256)
+        // then do the second mfcc with all new data(512).
+        // take mfcc buffer
+
+        for(int i=0; i<2; i++)
+        {
+            if ((audio_sample_i != 0 || i==1) && (audio_sample_i != 15872 || i==0)) //to skip computing first mfcc block that's half empty
+            {
+                mfcc_compute(mfcc, &audio_buffer_16bit[i*AUDIO_FRAME_LEN/2], mfcc_features_f);
+
+
+                // quantise them using the same scale as training data (in keras), by 2^n.
+                quantize_data(mfcc_features_f, mfcc_features[mfcc_feat_index], MFCC_COEFFS, 3);
+
+                // debug only, to print mfcc data on console
+                if(0)
+                {
+                    for(int q=0; q<MFCC_COEFFS; q++)
+                        printf("%d ",  mfcc_features[mfcc_feat_index][q]);
+                    printf("\n");
+                }
+
+                mfcc_feat_index++;
+                if(mfcc_feat_index >= MFCC_LEN)
+                    mfcc_feat_index = 0;
+            }
+
+        }
+}
+
+
+
+int main(void)
+{
+    uint32_t last_mfcc_index = 0;
+    uint32_t label;
+    float prob;
+    audio_sample_i = 0;
+    int s = 0; //number of audio samples to scan
+    float acc;
+    int correct = 0;
+    FILE * file;
+    FILE * ground_truth_f;
+    char str[10];
+    int j=0;
+    int F = 512;
+
+    file = fopen ("test_x.txt","r"); //the audio data stored in a textfile
+    ground_truth_f = fopen ("test_y.txt","r"); //the ground truth textfile
+
+     while (!feof (ground_truth_f))
+    {
+      fscanf (ground_truth_f, "%s", ground_truth[j]);
+      j++;
+    }
+    fclose (ground_truth_f);
+
+    int p = 0;
+
+    // create and compile the model
+    model = nnom_model_create();
+
+    while(1)
+    {
+      while (p<F)
+        {
+          fscanf(file, "%d", &dma_audio_buffer[p]);
+          p++;
+        }
+        p=0;
+        thread_kws_serv();
+        audio_sample_i = audio_sample_i + F;
+        if(audio_sample_i == 15872) //31*512
+            F = 128; //0.25*512
+        else
+            F = 512;
+
+        if(audio_sample_i>=16000)
+        {
+            // ML
+            memcpy(nnom_input_data, mfcc_features, MFCC_FEAT_SIZE);
+            nnom_predict(model, &label, &prob);
+
+            // output
+            printf("%d %s : %d%% - Ground Truth is: %s\n", s, (char*)&label_name[label], (int)(prob * 100),ground_truth[s]);
+            if(strcmp(ground_truth[s], label_name[label])==0) correct++;
+            if(s%100==0 && s > 0)
+            {
+                acc = ((float)correct/(s) * 100);
+                printf("Accuracy : %.6f%%\n",acc);
+            }
+            audio_sample_i = 0;
+            F = 512;
+            s=s+1;
+        }
+
+        if(s>=11000) break;
+    }
+    acc = ((float)correct/(s) * 100);
+    printf("Accuracy : %.6f%%\n",acc);
+    fclose(file);
+
+}

--- a/examples/keyword_spotting/mfcc.h
+++ b/examples/keyword_spotting/mfcc.h
@@ -23,7 +23,7 @@
 #define __MFCC_H__
 
 
-// in main.c define "PLATFORM_ARM" before including 'mfcc.h' to use ARM optimized FFT 
+// in main.c define "PLATFORM_ARM" before including 'mfcc.h' to use ARM optimized FFT
 #ifdef PLATFORM_ARM
 #include "arm_math.h"
 #define MFCC_PLATFORM_ARM
@@ -63,14 +63,14 @@ typedef struct _mfcc_t{
 } mfcc_t;
 
 static inline float InverseMelScale(float mel_freq) {
-  return 700.0f * (expf (mel_freq / 1127.0f) - 1.0f);
+  return 700.0f * (pow(10,(mel_freq / 2595.0f)) - 1.0f);
 }
 
 static inline float MelScale(float freq) {
-  return 1127.0f * logf (1.0f + freq / 700.0f);
+  return 2595.0f * log10(1.0f + freq / 700.0f);
 }
 
-float * create_dct_matrix(int32_t input_length, int32_t coefficient_count); 
+float * create_dct_matrix(int32_t input_length, int32_t coefficient_count);
 float ** create_mel_fbank(mfcc_t* mfcc);
 
 mfcc_t *mfcc_create(int num_mfcc_features, int feature_offset, int num_fbank, int frame_len, float preempha, int is_append_energy);

--- a/examples/keyword_spotting/mfcc.py
+++ b/examples/keyword_spotting/mfcc.py
@@ -27,8 +27,7 @@ def generate_mfcc(sig, rate, sig_len, noise=None, noise_weight=0.1, winlen=0.032
         if(len(sig) >sig_len):
             sig = sig[0:sig_len]
     # i dont know, 'tensorflow' normalization
-    sig = sig.astype('float') / 32768
-
+    sig = sig.astype('float32') / 32768
     if(noise is not None):
         noise = noise[random.randint(0, len(noise)-1)] # pick a noise
         start = random.randint(0, len(noise)-sig_len) # pick a sequence
@@ -59,7 +58,6 @@ def merge_mfcc_file(input_path='dat/', mix_noise=True, sig_len=16000, winlen=0.0
         test_list = f.read()
     with open(input_path +  'validation_list.txt', 'r') as f:
         validate_list = f.read()
-
     files = os.listdir(input_path)
     for fi in files:
         fi_d = os.path.join(input_path, fi)
@@ -68,6 +66,7 @@ def merge_mfcc_file(input_path='dat/', mix_noise=True, sig_len=16000, winlen=0.0
             label = fi_d.split('/')[1] # get the label from the dir
             print(label)
             # noise in training
+            
             if 'noise' in label:
                 for f in os.listdir(fi_d):
                     filename = f
@@ -76,6 +75,7 @@ def merge_mfcc_file(input_path='dat/', mix_noise=True, sig_len=16000, winlen=0.0
                     f = os.path.join(fi_d, f)
                     (rate, sig) = wav.read(f)
                     for i in range(0, len(sig), sig_len):
+                        
                         data = generate_mfcc(sig[i:i+sig_len], rate, sig_len, winlen=winlen, winstep=winstep, numcep=numcep,
                                              nfilt=nfilt, nfft=nfft, lowfreq=lowfreq,
                                              highfreq=highfreq, winfunc=winfunc, ceplifter=ceplifter, preemph=preemph)
@@ -87,22 +87,31 @@ def merge_mfcc_file(input_path='dat/', mix_noise=True, sig_len=16000, winlen=0.0
             # dataset
             for f in os.listdir(fi_d):
                 filename = f
+                
                 f = os.path.join(fi_d, f)
                 (rate, sig) = wav.read(f)
-                data = generate_mfcc(sig, rate, sig_len, noise=noise, winlen=winlen, winstep=winstep, numcep=numcep, nfilt=nfilt, nfft=nfft, lowfreq=lowfreq,
-                     highfreq=highfreq, winfunc=winfunc, ceplifter=ceplifter, preemph=preemph)
-                data = np.array(data) # ?? no idea why this works
 
                 # split dataset into train, test, validate
+                
                 if filename in test_list:
+                    data = generate_mfcc(sig, rate, sig_len, winlen=winlen, winstep=winstep, numcep=numcep, nfilt=nfilt, nfft=nfft, lowfreq=lowfreq, highfreq=highfreq, winfunc=winfunc, ceplifter=ceplifter, preemph=preemph)
+                    data = np.array(data) # ?? no idea why this works
+                    
                     test_data.append(data)
                     test_label.append(label)
+                
                 elif filename in validate_list:
+                    data = generate_mfcc(sig, rate, sig_len, winlen=winlen, winstep=winstep, numcep=numcep, nfilt=nfilt, nfft=nfft, lowfreq=lowfreq, highfreq=highfreq, winfunc=winfunc, ceplifter=ceplifter, preemph=preemph)
+                    data = np.array(data) # ?? no idea why this works
                     validate_data.append(data)
                     validate_label.append(label)
                 else:
+                    data = generate_mfcc(sig, rate, sig_len, noise=noise, winlen=winlen, winstep=winstep, numcep=numcep, nfilt=nfilt, nfft=nfft, lowfreq=lowfreq, highfreq=highfreq, winfunc=winfunc, ceplifter=ceplifter, preemph=preemph)
+                    data = np.array(data) # ?? no idea why this works
                     train_data.append(data)
                     train_lable.append(label)
+                
+
 
     # finalize
     train_data = np.array(train_data)
@@ -116,14 +125,14 @@ if __name__ == "__main__":
 
     # test
     (x_train, y_train), (x_test, y_test), (x_val, y_val) = merge_mfcc_file()
-
+    
     np.save('train_data.npy', x_train)
     np.save('train_label.npy', y_train)
     np.save('test_data.npy', x_test)
     np.save('test_label.npy', y_test)
     np.save('val_data.npy', x_val)
     np.save('val_label.npy', y_val)
-
+    
     print('x_train shape:', x_train.shape, 'max', x_train.max(), 'min', x_train.min())
 
     mfcc_feat = x_train[3948]


### PR DESCRIPTION
This fixes the mismatch between the MFCC in C vs in Python. To achieve this, the following was edited:
- forcing the datatypes in Python to be float32 throughout the process of generating the MFCC. 
- While investigating more, I changed the implementation of some internal function, e.x. hanning window generation, mel2hz and hz2mel to be consistent in both implementations.
- The main reasons the outputs were inconsistent were the following. First, the Mel-filter banks generation function in Python was different from its implementation in C. So, I took the algorithm in Python in wrote it in C to generate consistent filterbanks.
- Additionally, there was a mistake in the C implementation that it initially ignores the first coefficient which is fine since we take coefficient from 2:13. However, they later overwrite the first coefficient by the log of the total energy, while their replacement should take place to the first coefficient that they already skipped. So, I fixed this part as well.
- Finally, I edited some minor operations associated with data conversion for the MFCC outputs to be identical, e.x. flooring vs. ceiling, ..etc.

In addition to MFCC handling, I also created a simple program to test the KWS test data on PC by automating the process of reading the C arrays of the audio samples and feeding them into the model for inference to better learn about its performance and print the top-1 accuracy scores accordingly. The steps to run this program is updated in the KWS example ReadMe file. 