### PR TITLE
fix a memory leakage.

### DIFF
--- a/src/layers/nnom_output.c
+++ b/src/layers/nnom_output.c
@@ -29,6 +29,7 @@ nnom_layer_t *output_s(const nnom_io_config_t* config)
 		layer->type = NNOM_OUTPUT;
 		layer->run = output_run;
 		layer->build = default_build;
+		free(layer->in->tensor);  // free unused tensor.
 	}
 	return layer;
 }

--- a/src/layers/nnom_output.c
+++ b/src/layers/nnom_output.c
@@ -43,6 +43,7 @@ nnom_layer_t *Output(nnom_3d_shape_t output_shape, void *p_buf)
 		layer->type = NNOM_OUTPUT;
 		layer->run = output_run;
 		layer->build = default_build;
+		free(layer->in->tensor);  // free unused tensor.
 	}
 	return layer;
 }


### PR DESCRIPTION
in tensor of output layer cause memory leakage since the pointer is linked to the out tensor of previous layer. free the in tensor at output layer creation.