### PR TITLE
fix reshape output shape error.

### DIFF
--- a/src/layers/nnom_reshape.c
+++ b/src/layers/nnom_reshape.c
@@ -64,7 +64,7 @@ nnom_status_t reshape_build(nnom_layer_t *layer)
 	layer->in->tensor = layer->in->hook.io->tensor;
 
 	// create new tensor for output
-	layer->out->tensor = new_tensor(NNOM_QTYPE_PER_TENSOR, layer->in->tensor->num_dim, tensor_get_num_channel(layer->in->tensor));
+	layer->out->tensor = new_tensor(NNOM_QTYPE_PER_TENSOR, cl->num_dim, cl->dim[cl->num_dim-1]);
 	tensor_set_attr(layer->out->tensor, layer->in->tensor->q_dec, layer->in->tensor->q_offset, cl->dim, cl->num_dim, 8);
 
 	return NN_SUCCESS;


### PR DESCRIPTION
Reshape output shape error when run on 32bit cpu (eg. arm cortex-m).
For example, without this commit,
layer info:
......
#9   Dense 	 - HrdTanH  - (  96,          )     6144 (    64,    96,   128)
#10  Reshape -          - (   1,   3,   7,)          (    96,    21,     0)
#11  Concat  -          - (   1,   3,  39,)          (   117,   117,     0)
......
with this commit,
layer info:
......
#9   Dense   - HrdTanH  - (  96,          )     6144 (    64,    96,   128)
#10  Reshape -          - (   1,   3,  32,)          (    96,    96,     0)
#11  Concat  -          - (   1,   3,  64,)          (   192,   192,     0)
....