### PR TITLE
replace free() with nnom_free() in output layer

### DIFF
--- a/src/layers/nnom_output.c
+++ b/src/layers/nnom_output.c
@@ -29,7 +29,7 @@ nnom_layer_t *output_s(const nnom_io_config_t* config)
 		layer->type = NNOM_OUTPUT;
 		layer->run = output_run;
 		layer->build = default_build;
-		free(layer->in->tensor);  // free unused tensor.
+		nnom_free(layer->in->tensor);  // free unused tensor.
 	}
 	return layer;
 }
@@ -43,7 +43,7 @@ nnom_layer_t *Output(nnom_3d_shape_t output_shape, void *p_buf)
 		layer->type = NNOM_OUTPUT;
 		layer->run = output_run;
 		layer->build = default_build;
-		free(layer->in->tensor);  // free unused tensor.
+		nnom_free(layer->in->tensor);  // free unused tensor.
 	}
 	return layer;
 }


### PR DESCRIPTION
free() in output layer will cause core dump if use static memory block, so change to nnom_free().

#define NNOM_USING_STATIC_MEMORY 

log:
Model version: 0.4.3
free(): invalid pointer
Aborted (core dumped)