### PR TITLE
Fix Deprecated Usage of `np.int` in `to_cstyle` Function in `gen_config.py`

### DIFF
--- a/scripts/gen_config.py
+++ b/scripts/gen_config.py
@@ -16,7 +16,7 @@ def convert_tensor_name(t):
 def to_cstyle(data, integer=True):
     #Convert an array to C style basket, not to be used for very large array. size > options['threshold'] will lead to ...
     if(integer):
-        data = np.array(data, dtype=np.int).flatten()
+        data = np.array(data, dtype=np.int32).flatten()
     else:
         data = np.array(data).flatten()
     s = np.array2string(data, separator=',')


### PR DESCRIPTION
**Description:**
This pull request addresses the deprecated usage of `np.int` in the `to_cstyle` function within the `gen_config.py` script. The `np.int` usage has been replaced with `np.int32` to resolve the issue. The changes have been tested locally and verified to resolve the deprecated usage warning.

**Changes Made:**
- Replaced `np.int` with `np.int32` in the `to_cstyle` function

**Testing:**
- Tested the `to_cstyle` function with various input data to ensure correct behavior
- Verified that the deprecated usage warning no longer appears

**Related Issue:**
Fixes #212 
