### PR TITLE
examples: Fix exceptions due to np.int

### DIFF
--- a/examples/auto_test/README.md
+++ b/examples/auto_test/README.md
@@ -109,7 +109,7 @@ Data format in a testing binary file
     os.system(cmd)
     try:
         # get NNoM results
-        result = np.genfromtxt('result.csv', delimiter=',', dtype=np.int, skip_header=1)
+        result = np.genfromtxt('result.csv', delimiter=',', dtype=np.int32, skip_header=1)
         result = result[:,0]        # the first column is the label, the second is the probability
         label = y_test_original[:len(y_test)].flatten()     # use the original numerical label
         acc = np.sum(result == label).astype('float32')/len(result)

--- a/examples/auto_test/main.py
+++ b/examples/auto_test/main.py
@@ -145,7 +145,7 @@ def main():
     os.system(cmd)
     try:
         # get NNoM results
-        result = np.genfromtxt('result.csv', delimiter=',', dtype=np.int, skip_header=1)
+        result = np.genfromtxt('result.csv', delimiter=',', dtype=np.int32, skip_header=1)
         result = result[:,0]        # the first column is the label, the second is the probability
         label = y_test_original[:len(y_test)].flatten()     # use the original numerical label
         acc = np.sum(result == label).astype('float32')/len(result)

--- a/examples/uci-har-rnn/uci_rnn.py
+++ b/examples/uci-har-rnn/uci_rnn.py
@@ -238,7 +238,7 @@ def main():
     os.system(cmd)
     try:
         # get NNoM results
-        result = np.genfromtxt('result.csv', delimiter=',', dtype=np.int, skip_header=1)
+        result = np.genfromtxt('result.csv', delimiter=',', dtype=np.int32, skip_header=1)
         result = result[:,0]        # the first column is the label, the second is the probability
         label = y_test_original[:len(y_test)].flatten()     # use the original numerical label
         acc = np.sum(result == label).astype('float32')/len(result)


### PR DESCRIPTION
Will cause exceptions on recent numpy versions. With these fixes, at least auto_test works on numpy 1.24.3